### PR TITLE
chore: configure bun tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,11 @@ bun install
 bun run dev list
 bun run dev list --json
 ```
+
+### Testing
+
+See [TESTING.md](./TESTING.md) for details on running and contributing to tests. The short version:
+
+```bash
+bun test
+```

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,30 @@
+# Testing Guide
+
+This project uses [Bun](https://bun.sh) and its built‑in test runner. Tests live in the `tests` directory and use the `.test.ts` suffix.
+
+## Running Tests
+
+```bash
+bun test
+```
+
+The command above runs the full test suite. To run a single test file, provide its path:
+
+```bash
+bun test tests/worktree-manager.test.ts
+```
+
+## Writing Tests
+
+- Place new tests in the `tests/` folder.
+- Use `describe` and `it` blocks from `bun:test` for structure.
+- Name files after the module under test, e.g. `core.test.ts`.
+- Mock external CLI calls (Git, Docker, etc.) so tests remain fast and idempotent. The built-in `mock.module` helper from `bun:test` is used for this project.
+- Each new feature or bug fix should include corresponding tests.
+- Run `bun run format` before committing to ensure consistent style.
+
+## Contributing
+
+1. Create your tests following the guidelines above.
+2. Run `bun test` and ensure all tests pass.
+3. Submit your pull request with a clear description of the changes.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "build": "tsc",
         "build:watch": "tsc --watch",
         "dev": "bun src/cli.ts",
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "bun test",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "prepare": "husky"

--- a/tests/cli-apis.test.ts
+++ b/tests/cli-apis.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, test } from 'bun:test';
+import pkg from '../package.json' assert { type: 'json' };
+
+describe('viwo CLI APIs', () => {
+    it('exposes version from package.json', () => {
+        expect(pkg.version).toBeDefined();
+    });
+});
+
+test.todo('viwo settings allows configuring default AI tool');
+test.todo('viwo update upgrades the CLI to the latest version');
+test.todo('viwo help displays documentation');

--- a/tests/container-manager.test.ts
+++ b/tests/container-manager.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, test } from 'bun:test';
+import { generateContainerName, parseContainerName } from '../src/container-manager';
+
+describe('container manager', () => {
+    it('generates and parses container names', () => {
+        const name = generateContainerName('abc123', 'dev');
+        const parsed = parseContainerName(name);
+        expect(parsed?.worktreeId).toBe('abc123');
+        expect(parsed?.serviceType).toBe('dev');
+    });
+});
+
+test.todo('createContainer runs docker command');
+test.todo('listWorktreeContainers parses docker output');

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+describe('core worktree status', () => {
+    it('combines worktree and container data', async () => {
+        mock.module('../src/worktree-manager', () => ({
+            getWorktreeForWorktree: async () => ({
+                path: '/repo/viwo-abc-main',
+                branch: 'main',
+                worktreeId: 'abc',
+            }),
+        }));
+        mock.module('../src/container-manager', () => ({
+            getContainersForWorktree: async () => [
+                {
+                    id: '1',
+                    name: 'viwo-abc-dev-aaaaaa',
+                    status: 'Up 2 minutes',
+                    worktreeId: 'abc',
+                    serviceType: 'dev',
+                },
+            ],
+        }));
+        const { getWorktreeStatus } = await import('../src/core');
+        const status = await getWorktreeStatus('abc');
+        expect(status).toEqual({
+            worktreePath: '/repo/viwo-abc-main',
+            worktreeBranch: 'main',
+            containerIds: ['1'],
+            status: 'active',
+        });
+        mock.restore();
+    });
+});

--- a/tests/worktree-manager.test.ts
+++ b/tests/worktree-manager.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, test } from 'bun:test';
+import { generateWorktreeName, parseWorktreeName } from '../src/worktree-manager';
+
+describe('worktree manager', () => {
+    it('generates and parses worktree names', () => {
+        const name = generateWorktreeName('abc123', 'main');
+        expect(name).toBe('viwo-abc123-main');
+        expect(parseWorktreeName(name)).toEqual({ worktreeId: 'abc123', branch: 'main' });
+    });
+});
+
+test.todo('createWorktree executes git worktree add');
+test.todo('removeWorktree executes git worktree remove');
+test.todo('listExistingWorktrees parses git output');


### PR DESCRIPTION
## Summary
- add Bun test runner script and testing guide
- scaffold initial tests for worktree and container helpers
- document how to run and extend tests

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68c45a2c9a30832c8109798ff9b02469