### PR TITLE
[DEV-113] Docker attach feature for interactive sessions

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import {
     repoCommand,
     migrateCommand,
     authCommand,
+    attachCommand,
 } from './commands';
 
 const program = new Command();
@@ -26,6 +27,7 @@ program.addCommand(cleanupCommand);
 program.addCommand(repoCommand);
 program.addCommand(migrateCommand);
 program.addCommand(authCommand);
+program.addCommand(attachCommand);
 
 // Parse command line arguments
 program.parse();

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -1,0 +1,89 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { viwo } from '@viwo/core';
+
+export const attachCommand = new Command('attach')
+    .description('Attach to a running session container')
+    .argument('<session-id>', 'Session ID to attach to')
+    .action(async (sessionId: string) => {
+        try {
+            const id = parseInt(sessionId, 10);
+            if (isNaN(id)) {
+                console.error(chalk.red('Invalid session ID'));
+                process.exit(1);
+            }
+
+            // Get session details
+            const session = viwo.session.get({ id });
+            if (!session) {
+                console.error(chalk.red(`Session ${id} not found`));
+                process.exit(1);
+            }
+
+            if (!session.containerId) {
+                console.error(chalk.red(`Session ${id} has no container`));
+                process.exit(1);
+            }
+
+            // Check container status
+            const status = await viwo.docker.getContainerStatus({
+                containerId: session.containerId,
+            });
+
+            if (status !== 'running') {
+                console.error(chalk.red(`Container is not running (status: ${status})`));
+                process.exit(1);
+            }
+
+            // Set up TTY for raw mode
+            if (process.stdin.isTTY) {
+                process.stdin.setRawMode(true);
+            }
+
+            // Resize handler
+            const handleResize = () => {
+                if (process.stdout.isTTY) {
+                    viwo.docker
+                        .attachContainer({
+                            containerId: session.containerId!,
+                            stdin: process.stdin,
+                            stdout: process.stdout,
+                            stderr: process.stderr,
+                        })
+                        .catch(() => {
+                            // Ignore - we'll handle this in the main attach
+                        });
+                }
+            };
+
+            // Listen for resize events
+            process.stdout.on('resize', handleResize);
+
+            console.log(chalk.gray(`Attaching to session ${id}...`));
+            console.log(chalk.gray('Press Ctrl+C to detach\n'));
+
+            // Attach to the container
+            const result = await viwo.docker.attachContainer({
+                containerId: session.containerId,
+                stdin: process.stdin,
+                stdout: process.stdout,
+                stderr: process.stderr,
+            });
+
+            // Cleanup
+            process.stdout.removeListener('resize', handleResize);
+            if (process.stdin.isTTY) {
+                process.stdin.setRawMode(false);
+            }
+
+            console.log(chalk.gray(`\nContainer exited with code ${result.statusCode}`));
+            process.exit(result.statusCode);
+        } catch (error) {
+            // Restore terminal on error
+            if (process.stdin.isTTY) {
+                process.stdin.setRawMode(false);
+            }
+            console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+            process.exit(1);
+        }
+    });

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -5,3 +5,4 @@ export { cleanupCommand } from './cleanup';
 export { repoCommand } from './repo';
 export { migrateCommand } from './migrate';
 export { authCommand } from './auth';
+export { attachCommand } from './attach';

--- a/packages/core/src/managers/agent-manager.ts
+++ b/packages/core/src/managers/agent-manager.ts
@@ -21,23 +21,25 @@ export interface InitializeAgentOptions {
     config: AgentConfig;
 }
 
-export const initializeAgent = async (options: InitializeAgentOptions): Promise<void> => {
+export interface InitializeAgentResult {
+    containerId?: string;
+    containerName?: string;
+}
+
+export const initializeAgent = async (options: InitializeAgentOptions): Promise<InitializeAgentResult> => {
     switch (options.config.type) {
         case 'claude-code':
-            await initializeClaudeCode(options);
-            break;
+            return initializeClaudeCode(options);
         case 'cline':
-            await initializeCline(options);
-            break;
+            return initializeCline(options);
         case 'cursor':
-            await initializeCursor(options);
-            break;
+            return initializeCursor(options);
         default:
             throw new Error(`Unsupported agent type: ${options.config.type}`);
     }
 };
 
-const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<void> => {
+const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<InitializeAgentResult> => {
     const { sessionId, worktreePath, config } = options;
 
     // Check if Docker is running
@@ -156,8 +158,11 @@ const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<vo
     // This runs in the background and doesn't block the function return
     monitorContainerCompletion(sessionId, containerInfo.id);
 
-    // Return immediately without waiting for container to finish
-    // The container will run in the background
+    // Return container info for the caller to use
+    return {
+        containerId: containerInfo.id,
+        containerName: containerInfo.name,
+    };
 };
 
 /**
@@ -203,13 +208,13 @@ const monitorContainerCompletion = async (
     }
 };
 
-const initializeCline = async (_options: InitializeAgentOptions): Promise<void> => {
+const initializeCline = async (_options: InitializeAgentOptions): Promise<InitializeAgentResult> => {
     // Placeholder for Cline initialization
     // This would set up Cline-specific configuration
     throw new Error('Cline support not yet implemented');
 };
 
-const initializeCursor = async (_options: InitializeAgentOptions): Promise<void> => {
+const initializeCursor = async (_options: InitializeAgentOptions): Promise<InitializeAgentResult> => {
     // Placeholder for Cursor initialization
     // This would set up Cursor-specific configuration
     throw new Error('Cursor support not yet implemented');

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -63,6 +63,8 @@ export const WorktreeSessionSchema = z.object({
     createdAt: z.date(),
     lastActivity: z.date(),
     error: z.string().optional(),
+    containerId: z.string().optional(),
+    containerName: z.string().optional(),
 });
 export type WorktreeSession = z.infer<typeof WorktreeSessionSchema>;
 

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -106,7 +106,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                 }
 
                 // Initialize agent
-                await agent.initializeAgent({
+                const agentResult = await agent.initializeAgent({
                     sessionId: createdSession.id,
                     worktreePath,
                     config: {
@@ -115,6 +115,12 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                         model: 'sonnet',
                     },
                 });
+
+                // Store container info in the session
+                if (agentResult.containerId) {
+                    worktreeSession.containerId = agentResult.containerId;
+                    worktreeSession.containerName = agentResult.containerName;
+                }
 
                 // Run setup commands if specified
                 if (validatedOptions.setupCommands) {


### PR DESCRIPTION
## Summary

Implements docker attach workflow for fully interactive Claude Code sessions. Users can now run `viwo start` and immediately interact with Claude Code in their terminal, with the session persisting through Docker even after detaching.

## Changes

- Added `attachContainer()` function to docker-manager for bidirectional stream piping
- Extended WorktreeSession schema with containerId and containerName fields
- Modified start command to automatically attach to container (unless --detach flag used)
- New `viwo attach` command to re-attach to existing sessions
- Agent initialization now returns container info for session management

## Usage

```bash
# Interactive (default) - attaches automatically
viwo start

# Detached mode - runs in background
viwo start --detach

# Re-attach to running session
viwo attach <session-id>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)