### PR TITLE
[DEV-114] Create alias for viwo repo add as viwo register

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import {
     repoCommand,
     migrateCommand,
     authCommand,
+    registerCommand,
 } from './commands';
 
 const program = new Command();
@@ -26,6 +27,7 @@ program.addCommand(cleanupCommand);
 program.addCommand(repoCommand);
 program.addCommand(migrateCommand);
 program.addCommand(authCommand);
+program.addCommand(registerCommand);
 
 // Parse command line arguments
 program.parse();

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -5,3 +5,4 @@ export { cleanupCommand } from './cleanup';
 export { repoCommand } from './repo';
 export { migrateCommand } from './migrate';
 export { authCommand } from './auth';
+export { registerCommand } from './register';

--- a/packages/cli/src/commands/register.ts
+++ b/packages/cli/src/commands/register.ts
@@ -1,0 +1,40 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { viwo } from '@viwo/core';
+import { basename } from 'node:path';
+
+/**
+ * Register command - alias for 'repo add'
+ */
+export const registerCommand = new Command('register')
+    .description('Add a new repository (alias for "repo add")')
+    .argument('<path>', 'Path to the git repository')
+    .option('-n, --name <name>', 'Custom name for the repository')
+    .action(async (repoPath: string, options) => {
+        const spinner = ora('Adding repository...').start();
+        const possiblyRelativePath = repoPath === '.' ? process.cwd() : repoPath;
+        const lastBitOfPath = basename(possiblyRelativePath);
+
+        try {
+            const repo = await viwo.repo.create({
+                path: possiblyRelativePath,
+                name: options.name ?? lastBitOfPath,
+            });
+
+            spinner.succeed('Repository added successfully!');
+
+            console.log();
+            console.log(chalk.bold('Repository Details:'));
+            console.log(chalk.gray(' '.repeat(50)));
+            console.log(chalk.cyan('ID:       '), repo.id);
+            console.log(chalk.cyan('Name:     '), repo.name);
+            console.log(chalk.cyan('Path:     '), repo.path);
+            console.log(chalk.gray(' '.repeat(50)));
+            console.log();
+        } catch (error) {
+            spinner.fail('Failed to add repository');
+            console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+            process.exit(1);
+        }
+    });


### PR DESCRIPTION
## Summary

- Added a new `register` command as an alias for `repo add` to provide a more intuitive interface
- The command accepts a repository path and optional `--name` flag, mirroring the functionality of `repo add`
- Updated CLI command registration to include the new `registerCommand`

🤖 Generated with [Claude Code](https://claude.com/claude-code)