### PR TITLE
[DEV-115] Clean completed sessions with viwo clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,8 @@ Commands in `packages/cli/src/commands/`:
 - `start` - Initialize new session with prompt and agent
 - `list` - List all sessions
 - `get` - Get session details
-- `cleanup` - Remove session and resources
+- `cleanup` - Remove a specific session and its resources
+- `clean` - Clean up all completed, errored, or stopped sessions (marks as 'cleaned' and removes worktrees)
 - `repo` - Repository management (list, add, delete)
 
 ## Testing

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,6 +6,7 @@ import {
     listCommand,
     getCommand,
     cleanupCommand,
+    cleanCommand,
     repoCommand,
     migrateCommand,
     authCommand,
@@ -24,6 +25,7 @@ program.addCommand(startCommand);
 program.addCommand(listCommand);
 program.addCommand(getCommand);
 program.addCommand(cleanupCommand);
+program.addCommand(cleanCommand);
 program.addCommand(repoCommand);
 program.addCommand(migrateCommand);
 program.addCommand(authCommand);

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -1,0 +1,78 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { viwo } from '@viwo/core';
+import { SessionStatus } from '@viwo/core/schemas';
+
+export const cleanCommand = new Command('clean')
+    .description(
+        'Clean up all completed or errored sessions (removes worktrees and updates status)'
+    )
+    .option('--keep-worktree', 'Keep the worktree directories')
+    .option('--keep-containers', 'Keep containers running')
+    .option('--no-sync', 'Skip syncing Docker state before cleanup')
+    .option(
+        '--status <status>',
+        'Only clean sessions with specific status (completed, error, stopped)',
+        'completed,error,stopped'
+    )
+    .action(async (options) => {
+        const spinner = ora('Finding sessions to clean...').start();
+
+        try {
+            // Sync Docker state with database before cleanup
+            if (options.sync !== false) {
+                await viwo.sync();
+            }
+
+            // Parse status filter
+            const statusFilter = options.status.split(',').map((s: string) => s.trim());
+
+            // Get all sessions that match the status filter
+            const allSessions = await viwo.list();
+            const sessionsToClean = allSessions.filter((session) =>
+                statusFilter.includes(session.status)
+            );
+
+            if (sessionsToClean.length === 0) {
+                spinner.info(`No sessions found with status: ${statusFilter.join(', ')}`);
+                return;
+            }
+
+            spinner.text = `Found ${sessionsToClean.length} session(s) to clean...`;
+
+            let successCount = 0;
+            let errorCount = 0;
+
+            for (const session of sessionsToClean) {
+                spinner.text = `Cleaning session ${session.id} (${session.branchName})...`;
+
+                try {
+                    await viwo.cleanup({
+                        sessionId: session.id,
+                        removeWorktree: !options.keepWorktree,
+                        stopContainers: !options.keepContainers,
+                        removeContainers: !options.keepContainers,
+                    });
+                    successCount++;
+                } catch (error) {
+                    errorCount++;
+                    console.error(
+                        chalk.yellow(
+                            `\nWarning: Failed to clean session ${session.id}: ${error instanceof Error ? error.message : String(error)}`
+                        )
+                    );
+                }
+            }
+
+            if (errorCount === 0) {
+                spinner.succeed(`Successfully cleaned ${successCount} session(s)!`);
+            } else {
+                spinner.warn(`Cleaned ${successCount} session(s), ${errorCount} failed`);
+            }
+        } catch (error) {
+            spinner.fail('Failed to clean sessions');
+            console.error(chalk.red(error instanceof Error ? error.message : String(error)));
+            process.exit(1);
+        }
+    });

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -2,6 +2,7 @@ export { startCommand } from './start';
 export { listCommand } from './list';
 export { getCommand } from './get';
 export { cleanupCommand } from './cleanup';
+export { cleanCommand } from './clean';
 export { repoCommand } from './repo';
 export { migrateCommand } from './migrate';
 export { authCommand } from './auth';


### PR DESCRIPTION
## Summary

- Implements the `viwo clean` command to clean up completed, errored, or stopped sessions
- Updates session status to 'cleaned' and removes associated worktrees
- Provides a simple way to maintain workspace hygiene by removing inactive sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)