### PR TITLE
[DEV-117] Move database location to application data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,10 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 
 ### Database
 
-- **SQLite database** at repo root: `sqlite.db`
+- **SQLite database** stored in app data directory: `{app-data-path}/sqlite.db`
+  - macOS: `~/Library/Application Support/viwo/sqlite.db`
+  - Windows: `%APPDATA%/viwo/sqlite.db`
+  - Linux: `~/.local/share/viwo/sqlite.db`
 - **Drizzle ORM** with schemas in `packages/core/src/db-schemas/`
 - **Tables**: repositories, sessions, chats, configurations
 - **Migrations** in `packages/core/src/migrations/` - applied automatically on startup via `initializeDatabase()`

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,7 +1,15 @@
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import { initializeDatabase } from './db-init';
+import { joinDataPath } from './utils/paths';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 
-const sqlite = new Database('sqlite.db');
+const dbPath = joinDataPath('sqlite.db');
+
+// Ensure the app data directory exists
+mkdirSync(dirname(dbPath), { recursive: true });
+
+const sqlite = new Database(dbPath);
 initializeDatabase(sqlite);
 export const db = drizzle(sqlite);

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -20,9 +20,11 @@ import {
     updateSession,
 } from './managers/session-manager';
 import { getRepositoryById, repo } from './managers/repository-manager';
-import { joinWorktreesPath } from './utils/paths';
+import { joinDataPath, joinWorktreesPath } from './utils/paths';
 import { initializeDatabase } from './db-init';
 import { Database } from 'bun:sqlite';
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import { sessionToWorktreeSession } from './utils/types';
 import { db } from './db';
 
@@ -293,7 +295,9 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
         },
         async migrate() {
             console.log('Running database migrations...');
-            const sqlite = new Database('sqlite.db');
+            const dbPath = joinDataPath('sqlite.db');
+            mkdirSync(dirname(dbPath), { recursive: true });
+            const sqlite = new Database(dbPath);
             initializeDatabase(sqlite);
             console.log('Migrations complete!');
         },


### PR DESCRIPTION
## Summary

- Relocated SQLite database from repository root (`sqlite.db`) to platform-specific application data directories
- macOS: `~/Library/Application Support/viwo/sqlite.db`
- Windows: `%APPDATA%/viwo/sqlite.db`  
- Linux: `~/.local/share/viwo/sqlite.db`
- Updated `db.ts` and `viwo.ts` to use `joinDataPath()` utility and ensure directory creation
- Updated CLAUDE.md documentation to reflect new database location

This prevents database files from being tracked in git and follows OS conventions for application data storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)