### PR TITLE
[DEV-134] tests should not use production database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 - **Tables**: repositories, sessions, chats, configurations
 - **Migrations** in `packages/core/src/migrations/` - applied automatically on startup via `initializeDatabase()`
 - **Timestamp handling**: SQLite stores timestamps as TEXT in format `YYYY-MM-DD HH:MM:SS` using `CURRENT_TIMESTAMP`. The `parseSqliteTimestamp()` helper in `packages/core/src/utils/types.ts` converts these to JavaScript Date objects by transforming to ISO 8601 format.
+- **Test isolation**: Tests automatically use in-memory databases when run with `NODE_ENV=test`. The `packages/core/src/db.ts` module detects the test environment and uses `:memory:` instead of the production database file. For explicit control, tests can use `createTestDatabase()` from `packages/core/src/test-helpers/db.ts` to create isolated database instances.
 
 ### Core SDK Flow
 
@@ -133,10 +134,12 @@ Commands in `packages/cli/src/commands/`:
 
 Tests use Bun's native test runner (`bun:test`). Test files are in `__tests__` directories with `.test.ts` suffix.
 
+**Database isolation**: Tests automatically use in-memory databases to avoid overwriting production data. When running `bun run test` (or `bun test` directly in the core package), the `NODE_ENV=test` environment variable is set, which triggers the use of an in-memory SQLite database. Tests can also explicitly create isolated databases using `createTestDatabase()` from `packages/core/src/test-helpers/db.ts`.
+
 Current test coverage focuses on:
 - `git-manager.test.ts` - Branch name generation, repo validation
 - `docker-manager.test.ts` - Docker daemon status
-- `agent-manager.test.ts` - Claude Code agent initialization
+- `agent-manager.test.ts` - Claude Code agent initialization (demonstrates test database usage)
 
 ## Key Dependencies
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
     "build": "bun build src/index.ts --outdir dist --target node --format esm && tsc --emitDeclarationOnly",
     "db:generate": "bunx drizzle-kit generate --dialect sqlite --schema ./src/db-schemas/index.ts",
     "db:migrate": "bun scripts/generate-migrations.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "NODE_ENV=test bun test"
   },
   "files": [
     "dist",

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -5,11 +5,27 @@ import { joinDataPath } from './utils/paths';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-const dbPath = joinDataPath('sqlite.db');
+/**
+ * Get database path based on environment.
+ * Tests use a separate database to avoid overwriting production data.
+ */
+const getDbPath = (): string => {
+    // Check if running in test environment
+    if (process.env.NODE_ENV === 'test' || process.env.BUN_ENV === 'test') {
+        // Use in-memory database for tests
+        return ':memory:';
+    }
+    return joinDataPath('sqlite.db');
+};
 
-// Ensure the app data directory exists
-mkdirSync(dirname(dbPath), { recursive: true });
+const dbPath = getDbPath();
+
+// Only create directory if not using in-memory database
+if (dbPath !== ':memory:') {
+    mkdirSync(dirname(dbPath), { recursive: true });
+}
 
 const sqlite = new Database(dbPath);
 initializeDatabase(sqlite);
 export const db = drizzle(sqlite);
+export { sqlite };

--- a/packages/core/src/managers/__tests__/agent-manager.test.ts
+++ b/packages/core/src/managers/__tests__/agent-manager.test.ts
@@ -1,19 +1,27 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { initializeAgent } from '../agent-manager';
 import { AgentConfig } from '../../schemas';
+import { createTestDatabase } from '../../test-helpers/db';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
 
 describe('agent-manager', () => {
     let tempDir: string;
+    let testDb: ReturnType<typeof createTestDatabase>;
 
     beforeEach(() => {
+        // Create isolated test database
+        testDb = createTestDatabase();
+
         // Create a temporary directory for each test
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'viwo-test-'));
     });
 
     afterEach(() => {
+        // Clean up test database
+        testDb.close();
+
         // Clean up temporary directory
         if (fs.existsSync(tempDir)) {
             fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/core/src/test-helpers/db.ts
+++ b/packages/core/src/test-helpers/db.ts
@@ -1,0 +1,42 @@
+import { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { initializeDatabase } from '../db-init';
+
+/**
+ * Create an isolated in-memory database for testing.
+ * Each test can call this to get a fresh database instance.
+ *
+ * @example
+ * ```ts
+ * import { createTestDatabase } from '../test-helpers/db';
+ *
+ * describe('my test', () => {
+ *   let testDb;
+ *
+ *   beforeEach(() => {
+ *     testDb = createTestDatabase();
+ *   });
+ *
+ *   test('something', () => {
+ *     // Use testDb instead of the global db
+ *   });
+ * });
+ * ```
+ */
+export const createTestDatabase = () => {
+    const sqlite = new Database(':memory:');
+    initializeDatabase(sqlite);
+    const db = drizzle(sqlite);
+
+    return {
+        sqlite,
+        db,
+        /**
+         * Clean up the database connection.
+         * Call this in afterEach if needed.
+         */
+        close: () => {
+            sqlite.close();
+        },
+    };
+};


### PR DESCRIPTION
## Summary
- Implements automatic test database isolation using in-memory SQLite databases
- The `db.ts` module now detects `NODE_ENV=test` and uses `:memory:` instead of production database file
- Adds `createTestDatabase()` helper in `test-helpers/db.ts` for explicit test database creation
- Updates `agent-manager.test.ts` to demonstrate proper test database usage
- Adds `test` script to `package.json` that sets `NODE_ENV=test` automatically

## Test plan
- Run `bun run test` in packages/core and verify tests pass without touching production database
- Verify production database file is not created or modified during test execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)