### PR TITLE
[DEV-141] ability to change default ide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 - `agent-manager.ts` - AI agent initialization with automatic container lifecycle management (only Claude Code implemented)
 - `repository-manager.ts` - Repository CRUD
 - `port-manager.ts` - Port allocation via get-port
+- `config-manager.ts` - Configuration management (API keys, IDE preferences)
+- `ide-manager.ts` - IDE detection and launching
 
 **Schema-first validation** - All inputs validated with Zod schemas in `packages/core/src/schemas.ts`
 
@@ -129,6 +131,10 @@ Commands in `packages/cli/src/commands/`:
   - Keyboard-navigable list using @inquirer/prompts with session details and actions (cd to worktree, delete, go back)
 - `clean` - Clean up all completed, errored, or stopped sessions (marks as 'cleaned', removes worktrees, and runs `git worktree prune` for affected repositories)
 - `repo` - Repository management (list, add, delete)
+- `config ide` - Configure default IDE preference
+  - Interactive list showing available IDEs on the system
+  - Displays current default IDE setting
+  - Allows changing to a different IDE or removing the default (prompts each time)
 
 ## Testing
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import {
     migrateCommand,
     authCommand,
     registerCommand,
+    configCommand,
 } from './commands';
 import packageJson from '../package.json';
 
@@ -27,6 +28,7 @@ program.addCommand(repoCommand);
 program.addCommand(migrateCommand);
 program.addCommand(authCommand);
 program.addCommand(registerCommand);
+program.addCommand(configCommand);
 
 // Parse command line arguments
 program.parse();

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,171 @@
+import { Command } from 'commander';
+import { select } from '@inquirer/prompts';
+import chalk from 'chalk';
+import { IDEManager, ConfigManager, type IDEType, type IDEInfo } from '@viwo/core';
+
+const runIDEConfig = async (): Promise<void> => {
+	try {
+		console.clear();
+		console.log();
+		console.log(chalk.bold.cyan('IDE Configuration'));
+		console.log(chalk.gray('═'.repeat(70)));
+		console.log();
+
+		// Detect available IDEs
+		const availableIDEs = await IDEManager.detectAvailableIDEs();
+
+		if (availableIDEs.length === 0) {
+			console.log(chalk.yellow('No supported IDEs detected'));
+			console.log();
+			console.log(chalk.gray('Install one of the following:'));
+			console.log(chalk.cyan('  VSCode:    ') + chalk.gray('https://code.visualstudio.com'));
+			console.log(chalk.cyan('  Cursor:    ') + chalk.gray('https://cursor.sh'));
+			console.log(chalk.cyan('  JetBrains: ') + chalk.gray('https://www.jetbrains.com'));
+			console.log();
+			return;
+		}
+
+		// Get current preference
+		const currentPreference = ConfigManager.getPreferredIDE();
+
+		console.log(chalk.bold('Current Default IDE'));
+		if (currentPreference) {
+			console.log(
+				chalk.gray('  ') +
+					chalk.green(IDEManager.getIDEDisplayName(currentPreference)) +
+					chalk.gray(` (${currentPreference})`)
+			);
+		} else {
+			console.log(chalk.gray('  None - you will be prompted to choose each time'));
+		}
+		console.log();
+		console.log(chalk.gray('═'.repeat(70)));
+		console.log();
+
+		// Build choices
+		const choices = availableIDEs.map((ide: IDEInfo) => ({
+			name:
+				ide.type === currentPreference
+					? `${ide.name} ${chalk.green('(current)')}`
+					: ide.name,
+			value: ide.type,
+			description: ide.command,
+		}));
+
+		// Add separator and remove option
+		choices.push({
+			name: chalk.gray('─'.repeat(70)),
+			value: '__separator__' as IDEType,
+			description: '',
+		});
+
+		choices.push({
+			name: chalk.yellow('Remove default IDE'),
+			value: '__remove__' as IDEType,
+			description: 'You will be prompted to choose each time',
+		});
+
+		choices.push({
+			name: chalk.gray('❌ Cancel'),
+			value: '__cancel__' as IDEType,
+			description: 'Exit without changes',
+		});
+
+		// Show selection
+		const selection = await select<IDEType>({
+			message: 'Select your default IDE:',
+			choices,
+			pageSize: 15,
+		});
+
+		// Handle selection
+		if (selection === '__cancel__' || selection === '__separator__') {
+			console.log();
+			console.log(chalk.gray('No changes made'));
+			console.log();
+			return;
+		}
+
+		if (selection === '__remove__') {
+			// Remove default IDE
+			if (!currentPreference) {
+				console.log();
+				console.log(chalk.yellow('No default IDE is currently set'));
+				console.log();
+				return;
+			}
+
+			// Confirm removal
+			const confirmRemove = await select<boolean>({
+				message: chalk.yellow(
+					`Remove ${IDEManager.getIDEDisplayName(currentPreference)} as default IDE?`
+				),
+				choices: [
+					{ name: 'No, cancel', value: false },
+					{ name: 'Yes, remove', value: true },
+				],
+			});
+
+			if (confirmRemove) {
+				ConfigManager.deletePreferredIDE();
+				console.log();
+				console.log(chalk.green('✓ Default IDE removed'));
+				console.log(chalk.gray('  You will be prompted to choose an IDE each time'));
+				console.log();
+			} else {
+				console.log();
+				console.log(chalk.gray('No changes made'));
+				console.log();
+			}
+			return;
+		}
+
+		// Set new default IDE
+		if (selection === currentPreference) {
+			console.log();
+			console.log(
+				chalk.yellow(
+					`${IDEManager.getIDEDisplayName(selection)} is already your default IDE`
+				)
+			);
+			console.log();
+			return;
+		}
+
+		ConfigManager.setPreferredIDE(selection);
+		console.log();
+		console.log(
+			chalk.green(
+				`✓ Set ${IDEManager.getIDEDisplayName(selection)} as default IDE`
+			)
+		);
+		console.log();
+	} catch (error) {
+		if ((error as any).name === 'ExitPromptError') {
+			// User pressed Ctrl+C
+			console.log();
+			console.log(chalk.gray('Operation cancelled'));
+			console.log();
+			process.exit(0);
+		}
+		throw error;
+	}
+};
+
+const ideCommand = new Command('ide')
+	.description('Configure default IDE')
+	.action(async () => {
+		try {
+			await runIDEConfig();
+		} catch (error) {
+			console.error(
+				chalk.red('Configuration failed:'),
+				error instanceof Error ? error.message : String(error)
+			);
+			process.exit(1);
+		}
+	});
+
+export const configCommand = new Command('config')
+	.description('Manage VIWO configuration')
+	.addCommand(ideCommand);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -5,3 +5,4 @@ export { repoCommand } from './repo';
 export { migrateCommand } from './migrate';
 export { authCommand } from './auth';
 export { registerCommand } from './register';
+export { configCommand } from './config';

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -3,6 +3,7 @@ import { hostname, userInfo } from 'os';
 import { db } from '../db';
 import { configurations } from '../db-schemas';
 import { eq } from 'drizzle-orm';
+import type { IDEType } from '../types.js';
 
 const ALGORITHM = 'aes-256-gcm';
 const KEY_LENGTH = 32;
@@ -53,22 +54,6 @@ const decrypt = (encryptedData: string): string => {
 };
 
 export type ApiKeyProvider = 'anthropic';
-
-export type IDEType =
-	| 'vscode'
-	| 'vscode-insiders'
-	| 'cursor'
-	| 'webstorm'
-	| 'intellij-idea'
-	| 'intellij-idea-ce'
-	| 'pycharm'
-	| 'pycharm-ce'
-	| 'goland'
-	| 'phpstorm'
-	| 'rubymine'
-	| 'clion'
-	| 'datagrip'
-	| 'rider';
 
 export interface SetApiKeyOptions {
     provider: ApiKeyProvider;


### PR DESCRIPTION
## Summary
- Add new `viwo config ide` command for managing default IDE preferences
- Users can select from available IDEs on their system or remove the default setting
- Move `IDEType` from config-manager to central types.ts file
- Update CLAUDE.md documentation with new config command details

## Test plan
- [ ] Run `viwo config ide` and verify IDE selection interface appears
- [ ] Test selecting a default IDE and verify it's saved
- [ ] Test removing default IDE preference
- [ ] Verify IDE detection works correctly for installed IDEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)