### PR TITLE
[DEV-140] Add preflight check for update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,17 @@ Commands in `packages/cli/src/commands/`:
 - `clean` - Clean up all completed, errored, or stopped sessions (marks as 'cleaned', removes worktrees, and runs `git worktree prune` for affected repositories)
 - `repo` - Repository management (list, add, delete)
 
+### Prerequisites & Version Checking
+
+The CLI performs automatic prerequisite checks before running commands via `packages/cli/src/utils/prerequisites.ts`:
+- **Git installation** - Verifies git is available in PATH
+- **Docker daemon** - Checks if Docker is running
+- **Version check** - Compares current CLI version against latest GitHub release
+  - Fetches latest version from GitHub releases API (`/repos/OverseedAI/viwo/releases/latest`)
+  - Shows non-blocking warning when newer version is available
+  - Displays update instructions: re-run install script or download from GitHub releases
+  - Uses semantic version comparison (major.minor.patch)
+
 ## Testing
 
 Tests use Bun's native test runner (`bun:test`). Test files are in `__tests__` directories with `.test.ts` suffix.
@@ -140,6 +151,8 @@ Current test coverage focuses on:
 - `git-manager.test.ts` - Branch name generation, repo validation, worktree pruning
 - `docker-manager.test.ts` - Docker daemon status
 - `agent-manager.test.ts` - Claude Code agent initialization (demonstrates test database usage)
+- `prerequisites.test.ts` - Version comparison logic for update checking
+- `formatters.test.ts` - Date formatting utilities
 
 ## Key Dependencies
 

--- a/packages/cli/src/utils/__tests__/prerequisites.test.ts
+++ b/packages/cli/src/utils/__tests__/prerequisites.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'bun:test';
+import { isVersionOutdated } from '../prerequisites';
+
+describe('isVersionOutdated', () => {
+    it('should detect when current version is older (patch)', () => {
+        expect(isVersionOutdated('0.1.5', '0.1.6')).toBe(true);
+    });
+
+    it('should detect when current version is older (minor)', () => {
+        expect(isVersionOutdated('0.1.6', '0.2.0')).toBe(true);
+    });
+
+    it('should detect when current version is older (major)', () => {
+        expect(isVersionOutdated('0.1.6', '1.0.0')).toBe(true);
+    });
+
+    it('should return false when versions are equal', () => {
+        expect(isVersionOutdated('0.1.6', '0.1.6')).toBe(false);
+    });
+
+    it('should return false when current version is newer (patch)', () => {
+        expect(isVersionOutdated('0.1.7', '0.1.6')).toBe(false);
+    });
+
+    it('should return false when current version is newer (minor)', () => {
+        expect(isVersionOutdated('0.2.0', '0.1.6')).toBe(false);
+    });
+
+    it('should return false when current version is newer (major)', () => {
+        expect(isVersionOutdated('1.0.0', '0.1.6')).toBe(false);
+    });
+
+    it('should handle versions with v prefix', () => {
+        expect(isVersionOutdated('v0.1.5', 'v0.1.6')).toBe(true);
+        expect(isVersionOutdated('v0.1.6', 'v0.1.6')).toBe(false);
+    });
+
+    it('should handle versions without patch number', () => {
+        expect(isVersionOutdated('0.1', '0.2')).toBe(true);
+        expect(isVersionOutdated('0.2', '0.1')).toBe(false);
+    });
+
+    it('should handle versions with only major number', () => {
+        expect(isVersionOutdated('1', '2')).toBe(true);
+        expect(isVersionOutdated('2', '1')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

- Added automatic version checking that compares current CLI version against latest GitHub release
- Displays OS-specific update instructions (PowerShell for Windows, bash for macOS/Linux)
- Shows non-blocking warning when a newer version is available
- Implemented semantic version comparison with unit tests
- Updated CLAUDE.md documentation with prerequisites section

## Test plan

- [ ] Verify version check fetches from GitHub releases API
- [ ] Test update warning displays correctly on different operating systems
- [ ] Run unit tests for version comparison logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)