### PR TITLE
[DEV-146] Reverse viwo list order

### DIFF
--- a/packages/core/src/managers/session-manager.ts
+++ b/packages/core/src/managers/session-manager.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, desc } from 'drizzle-orm';
 import { db } from '../db';
 import { NewSession, Session, sessions } from '../db-schemas';
 
@@ -13,6 +13,8 @@ export const listSessions = (options: ListSessionsOptions = {}): Session[] => {
     if (options.status) {
         query = query.where(eq(sessions.status, options.status)) as typeof query;
     }
+
+    query = query.orderBy(desc(sessions.createdAt)) as typeof query;
 
     const results = query.all();
 


### PR DESCRIPTION
## Summary
- Modified `listSessions()` in `session-manager.ts` to order sessions by `createdAt` timestamp in descending order
- Sessions now display newest first, improving UX by showing most recent work at the top
- Added `desc` import from drizzle-orm and applied it to the query's orderBy clause

🤖 Generated with [Claude Code](https://claude.com/claude-code)