### PR TITLE
[DEV-161] view prompt does not do anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ viwo --help
 2. Changes are immediately available - no build step needed!
 3. Run the CLI to test your changes:
    ```bash
-   viwo init --prompt "Your task here"
+   viwo start
    ```
 
 The core package uses **direct TypeScript source imports** - Bun's native TypeScript support makes this possible without compilation during development.
@@ -200,9 +200,7 @@ bun run lint
 ### Initialize a new session
 
 ```bash
-viwo init --prompt "Add user authentication feature" \
-  --agent claude-code \
-  --branch feat/auth
+viwo start
 ```
 
 ### List all sessions

--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -165,7 +165,7 @@ export const runInteractiveList = async (options: { status?: SessionStatus; limi
                 console.log(chalk.yellow('No sessions found.'));
                 console.log(
                     chalk.gray('Create a new session with: ') +
-                        chalk.cyan('viwo start --prompt "your task"')
+                        chalk.cyan('viwo start')
                 );
                 console.log();
                 break;


### PR DESCRIPTION
## Summary

Updated documentation to reflect the current CLI interface where `viwo start` is the primary command for creating sessions. Removed outdated references to `viwo init` with command-line arguments in favor of the interactive prompt-based flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)