### PR TITLE
[DEV-159] Breakline in list mode should not be selectable

### DIFF
--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -1,4 +1,4 @@
-import { select } from '@inquirer/prompts';
+import { select, Separator } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { SessionStatus, viwo, type WorktreeSession } from '@viwo/core';
 import { getStatusBadge, formatDate } from '../utils/formatters';
@@ -183,11 +183,7 @@ export const runInteractiveList = async (options: { status?: SessionStatus; limi
                 description: `${session.agent.type} | ${session.id.substring(0, 12)}`,
             }));
 
-            choices.push({
-                name: chalk.gray('─'.repeat(70)),
-                value: '__separator__',
-                description: '',
-            });
+            choices.push(new Separator(chalk.gray('─'.repeat(70))));
 
             choices.push({
                 name: chalk.gray('❌ Exit'),
@@ -203,10 +199,6 @@ export const runInteractiveList = async (options: { status?: SessionStatus; limi
 
             if (selectedId === '__exit__') {
                 break;
-            }
-
-            if (selectedId === '__separator__') {
-                continue;
             }
 
             // Fetch the full session details

--- a/packages/cli/src/commands/repo-list-interactive.ts
+++ b/packages/cli/src/commands/repo-list-interactive.ts
@@ -1,4 +1,4 @@
-import { select } from '@inquirer/prompts';
+import { select, Separator } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { viwo } from '@viwo/core';
 import { formatDate } from '../utils/formatters';
@@ -144,11 +144,7 @@ export const runInteractiveRepoList = async () => {
                     : `ID: ${repo.id}`,
             }));
 
-            choices.push({
-                name: chalk.gray('─'.repeat(70)),
-                value: -999999, // Use special number for separator
-                description: '',
-            });
+            choices.push(new Separator(chalk.gray('─'.repeat(70))));
 
             choices.push({
                 name: chalk.gray('➕ Add new repository'),
@@ -170,10 +166,6 @@ export const runInteractiveRepoList = async () => {
 
             if (selectedId === -777777) {
                 break;
-            }
-
-            if (selectedId === -999999) {
-                continue;
             }
 
             if (selectedId === -888888) {


### PR DESCRIPTION
## Summary
- Replace disabled choice objects with `Separator` class from `@inquirer/prompts` for visual breaklines
- Remove unnecessary handling logic for separator values since `Separator` instances are automatically non-selectable
- Applies fix to both session list (`list-interactive.ts`) and repository list (`repo-list-interactive.ts`) views

This ensures breaklines appear as purely aesthetic separators without showing "(disabled)" indicators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)