### PR TITLE
[DEV-160] Config for default worktree location

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -159,6 +159,7 @@ export const startCommand = new Command('start')
 
             // Attach to container and stream output
             const dbSession = await viwo.get(session.id);
+
             if (dbSession && dbSession.containers.length > 0) {
                 console.log();
                 console.log(chalk.dim('───────────────────────────────────────────────────────'));
@@ -176,12 +177,18 @@ export const startCommand = new Command('start')
                     });
 
                     console.log();
-                    console.log(chalk.dim('───────────────────────────────────────────────────────'));
+                    console.log(
+                        chalk.dim('───────────────────────────────────────────────────────')
+                    );
                     console.log(chalk.yellow('Detached from container'));
                     console.log(
-                        chalk.dim(`Container ${dbSession.containers[0].id} is still running in the background`)
+                        chalk.dim(
+                            `Container ${dbSession.containers[0].id} is still running in the background`
+                        )
                     );
-                    console.log(chalk.dim('───────────────────────────────────────────────────────'));
+                    console.log(
+                        chalk.dim('───────────────────────────────────────────────────────')
+                    );
                 } catch (attachError) {
                     console.error(
                         chalk.yellow('\nFailed to attach to container:'),

--- a/packages/core/drizzle/0005_confused_the_renegades.sql
+++ b/packages/core/drizzle/0005_confused_the_renegades.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `configurations` ADD `worktrees_storage_location` text;

--- a/packages/core/drizzle/meta/0005_snapshot.json
+++ b/packages/core/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,271 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "124e3bfd-66a2-4b0c-865a-a541aea8233c",
+  "prevId": "042d285b-8040-4f62-9c73-daefbe35d2fd",
+  "tables": {
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repoId": {
+          "name": "repoId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gitWorktreeName": {
+          "name": "gitWorktreeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerName": {
+          "name": "containerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerId": {
+          "name": "containerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerImage": {
+          "name": "containerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'initializing'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "lastActivity": {
+          "name": "lastActivity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "configurations": {
+      "name": "configurations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_ide": {
+          "name": "preferred_ide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktrees_storage_location": {
+          "name": "worktrees_storage_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1764116397950,
       "tag": "0004_puzzling_anita_blake",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1764892109788,
+      "tag": "0005_confused_the_renegades",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db-schemas/configuration.ts
+++ b/packages/core/src/db-schemas/configuration.ts
@@ -4,6 +4,7 @@ export const configurations = sqliteTable('configurations', {
     id: integer('id').primaryKey(),
     anthropicApiKey: text('anthropic_api_key'),
     preferredIde: text('preferred_ide'),
+    worktreesStorageLocation: text('worktrees_storage_location'),
     createdAt: text('created_at'),
     updatedAt: text('updated_at'),
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,3 +34,4 @@ export {
 
 // Export path utilities
 export * from './utils/paths';
+export { AppPaths } from './utils/paths';

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -107,5 +107,12 @@ export const migrations: Migration[] = [
         up: `
             ALTER TABLE \`configurations\` ADD \`preferred_ide\` text;
         `
+    },
+    {
+        version: 6,
+        name: 'confused_the_renegades',
+        up: `
+            ALTER TABLE \`configurations\` ADD \`worktrees_storage_location\` text;
+        `
     }
 ];

--- a/packages/core/src/utils/__tests__/paths.test.ts
+++ b/packages/core/src/utils/__tests__/paths.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'bun:test';
+import { expandTilde } from '../paths';
+import { homedir } from 'node:os';
+
+describe('expandTilde', () => {
+	it('should expand ~ to home directory', () => {
+		const result = expandTilde('~');
+		expect(result).toBe(homedir());
+	});
+
+	it('should expand ~/ to home directory with path', () => {
+		const result = expandTilde('~/.config/viwo');
+		expect(result).toBe(`${homedir()}/.config/viwo`);
+	});
+
+	it('should not modify absolute paths', () => {
+		const result = expandTilde('/home/user/viwo');
+		expect(result).toBe('/home/user/viwo');
+	});
+
+	it('should not modify relative paths without tilde', () => {
+		const result = expandTilde('relative/path');
+		expect(result).toBe('relative/path');
+	});
+
+	it('should not expand tilde in the middle of a path', () => {
+		const result = expandTilde('/some/path/~/file');
+		expect(result).toBe('/some/path/~/file');
+	});
+});


### PR DESCRIPTION
## Summary
- Adds tilde expansion support (`~/.config/viwo`) for worktrees storage location configuration
- Fixes bug where tilde paths were incorrectly appended to app data directory instead of being expanded to home directory
- Adds `expandTilde()` utility function with comprehensive test coverage
- Updates CLI to properly display default location vs current configured location

🤖 Generated with [Claude Code](https://claude.com/claude-code)