### PR TITLE
[DEV-158] after session creation ctrlc doesnt seem to work

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -189,16 +189,19 @@ export const startCommand = new Command('start')
                     console.log(
                         chalk.dim('───────────────────────────────────────────────────────')
                     );
+                    console.log();
+                    clack.outro(`Next: ${chalk.cyan(`cd "${session.worktreePath}"`)} to view results!`);
+                    process.exit(0);
                 } catch (attachError) {
                     console.error(
                         chalk.yellow('\nFailed to attach to container:'),
                         attachError instanceof Error ? attachError.message : String(attachError)
                     );
+                    console.log();
+                    clack.outro(`Next: ${chalk.cyan(`cd "${session.worktreePath}"`)} to view results!`);
+                    process.exit(0);
                 }
             }
-
-            console.log();
-            clack.outro(`Next: ${chalk.cyan(`cd "${session.worktreePath}"`)} to view results!`);
         } catch (error) {
             clack.cancel(error instanceof Error ? error.message : String(error));
             process.exit(1);


### PR DESCRIPTION
## Summary
- Fixes CLI not cleanly exiting after CTRL+C during container attachment
- Adds `process.exit(0)` calls after successful and failed attachment attempts
- Moves outro message inside try/catch blocks to display before exit

## Test plan
- [ ] Run `viwo start` and press CTRL+C during container output streaming
- [ ] Verify CLI displays outro message and exits cleanly
- [ ] Verify container continues running in background after detach

🤖 Generated with [Claude Code](https://claude.com/claude-code)