### PR TITLE
[DEV-167] in session details remove the outer box

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -146,16 +146,14 @@ export const startCommand = new Command('start')
 
             spinner.stop('Session created successfully!');
 
-            clack.note(
-                [
-                    `${chalk.cyan('ID:')}        ${session.id}`,
-                    `${chalk.cyan('Branch:')}    ${session.branchName}`,
-                    `${chalk.cyan('Worktree:')}  ${session.worktreePath}`,
-                    `${chalk.cyan('Agent:')}     ${session.agent.type}`,
-                    `${chalk.cyan('Status:')}    ${getStatusBadge(session.status)}`,
-                ].join('\n'),
-                'Session Details'
-            );
+            console.log();
+            console.log(chalk.bold('Session Details'));
+            console.log();
+            console.log(`  ${chalk.cyan('ID:')}        ${session.id}`);
+            console.log(`  ${chalk.cyan('Branch:')}    ${session.branchName}`);
+            console.log(`  ${chalk.cyan('Worktree:')}  ${session.worktreePath}`);
+            console.log(`  ${chalk.cyan('Agent:')}     ${session.agent.type}`);
+            console.log(`  ${chalk.cyan('Status:')}    ${getStatusBadge(session.status)}`);
 
             // Attach to container and stream output
             const dbSession = await viwo.get(session.id);


### PR DESCRIPTION
## Summary
Simplifies the session details display in the `start` command by replacing `clack.note()` with direct `console.log()` calls. This removes the outer box border while preserving the same information and visual styling.

## Changes
- Replaced `clack.note()` with plain console logging for session details
- Maintained the same layout and cyan-colored labels (ID, Branch, Worktree, Agent, Status)
- Reduced visual clutter by removing the box border around session information

🤖 Generated with [Claude Code](https://claude.com/claude-code)