### PR TITLE
[DEV-165] Run migrations as part of preflight check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,9 +183,10 @@ Commands in `packages/cli/src/commands/`:
   - Set custom location (absolute or relative to app data directory)
   - Reset to default location (app data directory)
 
-### Prerequisites & Version Checking
+### Preflight Checks & Version Checking
 
-The CLI performs automatic prerequisite checks before running commands via `packages/cli/src/utils/prerequisites.ts`:
+The CLI performs automatic preflight checks before running commands via `packages/cli/src/utils/prerequisites.ts`:
+- **Database migration** - Runs `viwo.migrate()` to ensure the database is up to date
 - **Git installation** - Verifies git is available in PATH
 - **Docker daemon** - Checks if Docker is running
 - **Version check** - Compares current CLI version against latest GitHub release
@@ -193,6 +194,12 @@ The CLI performs automatic prerequisite checks before running commands via `pack
   - Shows non-blocking warning when newer version is available
   - Displays update instructions: re-run install script or download from GitHub releases
   - Uses semantic version comparison (major.minor.patch)
+
+The main function is `preflightChecksOrExit()` which:
+- Runs database migrations first (exits on failure)
+- Checks for git and Docker availability (configurable via options)
+- Shows version update warnings (non-blocking)
+- Called by all CLI commands including `viwo config` commands
 
 ## Testing
 

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import { viwo } from '@viwo/core';
-import { checkPrerequisitesOrExit } from '../utils/prerequisites';
+import { preflightChecksOrExit } from '../utils/prerequisites';
 
 export const cleanCommand = new Command('clean')
     .description(
@@ -18,8 +18,8 @@ export const cleanCommand = new Command('clean')
     )
     .action(async (options) => {
         try {
-            // Check prerequisites before proceeding
-            await checkPrerequisitesOrExit();
+            // Run preflight checks before proceeding
+            await preflightChecksOrExit();
 
             const spinner = ora('Finding sessions to clean...').start();
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -3,9 +3,13 @@ import { select, input } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { IDEManager, ConfigManager, type IDEType, type IDEInfo, AppPaths } from '@viwo/core';
 import { isAbsolute } from 'path';
+import { preflightChecksOrExit } from '../utils/prerequisites';
 
 const runIDEConfig = async (): Promise<void> => {
 	try {
+		// Run preflight checks before proceeding
+		await preflightChecksOrExit({ requireGit: false, requireDocker: false });
+
 		console.clear();
 		console.log();
 		console.log(chalk.bold.cyan('IDE Configuration'));
@@ -169,6 +173,9 @@ const ideCommand = new Command('ide')
 
 const runWorktreesLocationConfig = async (): Promise<void> => {
 	try {
+		// Run preflight checks before proceeding
+		await preflightChecksOrExit({ requireGit: false, requireDocker: false });
+
 		console.clear();
 		console.log();
 		console.log(chalk.bold.cyan('Worktrees Storage Location'));

--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -2,7 +2,7 @@ import { select, Separator } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { SessionStatus, viwo, type WorktreeSession } from '@viwo/core';
 import { getStatusBadge, formatDate } from '../utils/formatters';
-import { checkPrerequisitesOrExit } from '../utils/prerequisites';
+import { preflightChecksOrExit } from '../utils/prerequisites';
 import { selectAndOpenIDE } from '../utils/ide-selector';
 
 const displaySessionDetails = async (session: WorktreeSession) => {
@@ -150,7 +150,7 @@ export const runInteractiveList = async (options: { status?: SessionStatus; limi
             // Check prerequisites before syncing
             // Sync Docker state with database before listing
             if (options.status === undefined || options.limit === undefined) {
-                // await checkPrerequisitesOrExit({ requireGit: false });
+                await preflightChecksOrExit({ requireGit: false });
                 await viwo.sync();
             }
 

--- a/packages/cli/src/commands/repo.ts
+++ b/packages/cli/src/commands/repo.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { viwo } from '@viwo/core';
 import { basename } from 'node:path';
-import { checkPrerequisitesOrExit } from '../utils/prerequisites';
+import { preflightChecksOrExit } from '../utils/prerequisites';
 import { runInteractiveRepoList } from './repo-list-interactive';
 
 export const repoCommand = new Command('repo').description('Manage repositories');
@@ -32,8 +32,8 @@ repoCommand
     .argument('[path]', 'Path to the git repository (defaults to current directory)', process.cwd())
     .option('-n, --name <name>', 'Custom name for the repository')
     .action(async (repoPath: string, options) => {
-        // Check prerequisites before proceeding
-        await checkPrerequisitesOrExit({ requireDocker: false });
+        // Run preflight checks before proceeding
+        await preflightChecksOrExit({ requireDocker: false });
 
         const spinner = ora('Adding repository...').start();
         const possiblyRelativePath = repoPath === '.' ? process.cwd() : repoPath;

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -4,7 +4,7 @@ import * as clack from '@clack/prompts';
 import * as readline from 'readline';
 import { viwo, AttachManager } from '@viwo/core';
 import { getStatusBadge } from '../utils/formatters';
-import { checkPrerequisitesOrExit } from '../utils/prerequisites';
+import { preflightChecksOrExit } from '../utils/prerequisites';
 
 /**
  * Prompts for multiline text input that supports pasting multiple lines.
@@ -60,8 +60,8 @@ export const startCommand = new Command('start')
     .option('--no-sync', 'Skip syncing Docker state before starting')
     .action(async (options) => {
         try {
-            // Check prerequisites before proceeding
-            await checkPrerequisitesOrExit();
+            // Run preflight checks before proceeding
+            await preflightChecksOrExit();
 
             // Sync Docker state with database before starting
             if (options.sync !== false) {


### PR DESCRIPTION
## Summary

This PR renames prerequisite checks to "preflight checks" and adds automatic database migration execution at the beginning of the check sequence. This ensures the database schema is always up to date before any CLI command runs.

- Renamed `checkPrerequisitesOrExit` to `preflightChecksOrExit` to better reflect expanded scope
- Database migrations now run automatically before git/Docker checks in all commands
- Updated all CLI commands (start, clean, list, repo, config) to use the new function
- Documentation updated to reflect the new preflight checks architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)