### PR TITLE
[DEV-174] Option to show full container output

### DIFF
--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -76,6 +76,11 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
             disabled: !session.worktreePath,
         },
         {
+            name: '📄 View full container output',
+            value: 'view-output',
+            disabled: !session.containerOutput,
+        },
+        {
             name: '🗑️  Delete session',
             value: 'delete',
         },
@@ -102,6 +107,34 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
                 process.stdin.once('data', resolve);
             });
             return 'back';
+
+        case 'view-output': {
+            console.clear();
+            console.log();
+            console.log(chalk.bold.cyan('Container Output'));
+            console.log(chalk.gray('═'.repeat(70)));
+            console.log();
+            console.log(session.containerOutput);
+            console.log();
+            console.log(chalk.gray('═'.repeat(70)));
+            console.log();
+            console.log(chalk.gray('Press Enter to go back...'));
+
+            // Set stdin to resume and wait for actual user input
+            process.stdin.resume();
+            process.stdin.setRawMode(false);
+            await new Promise((resolve) => {
+                const handler = () => {
+                    process.stdin.pause();
+                    resolve(undefined);
+                };
+                process.stdin.once('data', handler);
+            });
+
+            // Redisplay session details
+            await displaySessionDetails(session);
+            return await handleSessionAction(session);
+        }
 
         case 'delete': {
             console.log();


### PR DESCRIPTION
## Summary
- Added "View full container output" action to interactive session details
- Option is conditionally enabled only when container output exists
- Properly configures stdin (resume, setRawMode, pause) to wait for user input before returning to session details

## Test plan
- Run `viwo list` and select a completed/errored session with container output
- Verify the new "📄 View full container output" option appears
- Select the option and verify full output is displayed
- Press Enter and verify it returns to the session details view

🤖 Generated with [Claude Code](https://claude.com/claude-code)