### PR TITLE
[DEV-178] intellij idea open in ide doesnt work

### DIFF
--- a/packages/core/src/managers/ide-manager.ts
+++ b/packages/core/src/managers/ide-manager.ts
@@ -77,7 +77,10 @@ const IDE_CONFIGS: IDEConfig[] = [
         name: 'IntelliJ IDEA Ultimate',
         command: 'idea',
         paths: {
-            darwin: ['/Applications/IntelliJ IDEA.app'],
+            darwin: [
+                '/Applications/IntelliJ IDEA.app',
+                '/Applications/IntelliJ IDEA Ultimate.app',
+            ],
             linux: [
                 '/opt/jetbrains/idea/bin/idea.sh',
                 `${process.env.HOME}/.local/share/JetBrains/Toolbox/apps/IDEA-U/bin/idea.sh`,
@@ -90,7 +93,10 @@ const IDE_CONFIGS: IDEConfig[] = [
         name: 'IntelliJ IDEA Community',
         command: 'idea-ce',
         paths: {
-            darwin: ['/Applications/IntelliJ IDEA CE.app'],
+            darwin: [
+                '/Applications/IntelliJ IDEA CE.app',
+                '/Applications/IntelliJ IDEA Community Edition.app',
+            ],
             linux: [
                 '/opt/jetbrains/idea-ce/bin/idea.sh',
                 `${process.env.HOME}/.local/share/JetBrains/Toolbox/apps/IDEA-C/bin/idea.sh`,


### PR DESCRIPTION
## Summary
- Added additional macOS application paths for IntelliJ IDEA Ultimate and Community editions
- Fixes detection issues where IntelliJ IDEA wasn't being found due to alternate application naming conventions
- Includes both standard installation paths and alternate names like "IntelliJ IDEA Ultimate.app" and "IntelliJ IDEA Community Edition.app"

## Test plan
- [ ] Verify IntelliJ IDEA Ultimate detection on macOS with standard installation
- [ ] Verify IntelliJ IDEA Ultimate detection with alternate app name
- [ ] Verify IntelliJ IDEA Community detection with both naming conventions
- [ ] Test that `viwo config ide` command shows IntelliJ variants when installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)