### PR TITLE
[DEV-185] In viwo list show the latest repo used first

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -37,7 +37,7 @@ export const startCommand = new Command('start')
                     process.exit(1);
                 }
             } else {
-                const repositories = viwo.repo.list({ archived: false });
+                const repositories = viwo.repo.list({ archived: false, orderByRecentlyUsed: true });
 
                 if (repositories.length === 0) {
                     clack.cancel('No repositories found.');


### PR DESCRIPTION
## Summary
- Add `orderByRecentlyUsed` option to `listRepositories()` that orders repositories by their most recent session activity
- Update the `viwo start` command to show repositories in order of most recently used
- Uses a LEFT JOIN with sessions table and orders by MAX(lastActivity) timestamp

## Test plan
- [ ] Run `viwo start` and verify repositories are ordered by most recently used
- [ ] Verify that repositories with no sessions still appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)