### PR TITLE
feat: add OAuth/Claude subscription authentication support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 - `agent-manager.ts` - AI agent initialization with automatic container lifecycle management (only Claude Code implemented)
 - `repository-manager.ts` - Repository CRUD
 - `port-manager.ts` - Port allocation via get-port
-- `config-manager.ts` - Configuration management (API keys, IDE preferences, worktrees storage location)
+- `config-manager.ts` - Configuration management (API keys, auth method, IDE preferences, worktrees storage location)
+- `credential-manager.ts` - OAuth credential extraction from host system (macOS Keychain, Linux credential files)
 - `ide-manager.ts` - IDE detection and launching
 - `project-config-manager.ts` - Project configuration file detection and parsing (viwo.yml/viwo.yaml)
 
@@ -101,6 +102,7 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 - **Tables**: repositories, sessions, chats, configurations
 - **Configuration storage**: The `configurations` table stores user preferences including:
   - API keys (encrypted)
+  - Auth method (`'api-key'` or `'oauth'`)
   - Preferred IDE
   - Worktrees storage location (supports absolute or relative paths)
 - **Session storage**: The `sessions` table stores worktree session details including:
@@ -161,6 +163,21 @@ Git worktrees storage location is configurable through the `config-manager.ts`:
   - `getWorktreesStorageLocation()` - Get current custom location (null if using default)
   - `deleteWorktreesStorageLocation()` - Reset to default location
 
+### Authentication
+
+VIWO supports two authentication methods, configured via `viwo auth`:
+
+- **API Key** (`auth_method = 'api-key'`): Traditional Anthropic API key (`sk-ant-api...`). Stored encrypted in the SQLite database. Passed to Docker container as `ANTHROPIC_API_KEY` env var.
+
+- **OAuth / Claude Subscription** (`auth_method = 'oauth'`): For Claude Max, Pro, and Teams users. Credentials are extracted from the host's Claude Code installation at each session start (not stored in VIWO's database):
+  - **macOS**: Read from Keychain service `"Claude Code-credentials"` via `security` CLI
+  - **Linux**: Read from `~/.claude/.credentials.json`
+  - Passed to container as `VIWO_OAUTH_CREDENTIALS` and `VIWO_OAUTH_ACCOUNT` env vars
+  - The bootstrap script (`claude-bootstrap.sh`) writes them to `~/.claude/.credentials.json` inside the container, which Claude Code reads natively on Linux
+  - Access tokens expire but Claude Code auto-refreshes using the refresh token
+
+The `credential-manager.ts` handles host credential extraction, and `config-manager.ts` stores the auth method preference.
+
 ### Container Lifecycle Management
 
 The `agent-manager.ts` implements automatic container cleanup:
@@ -201,6 +218,10 @@ Commands in `packages/cli/src/commands/`:
 - `list` - List all sessions in interactive mode
   - Keyboard-navigable list using @inquirer/prompts with session details and actions (cd to worktree, delete, go back)
 - `clean` - Clean up all completed, errored, stopped, or initializing sessions (marks as 'cleaned', removes worktrees, deletes associated local branches, and runs `git worktree prune` for affected repositories)
+- `auth` - Configure authentication method
+  - Choose between Claude subscription (OAuth auto-detect) or Anthropic API key
+  - OAuth mode detects credentials from host's Claude Code installation
+  - Displays subscription details (email, org, expiry) for confirmation
 - `repo` - Repository management (list, add, delete)
 - `config ide` - Configure default IDE preference
   - Interactive list showing available IDEs on the system
@@ -239,6 +260,7 @@ Current test coverage focuses on:
 - `git-manager.test.ts` - Branch name generation, repo validation, worktree pruning
 - `docker-manager.test.ts` - Docker daemon status
 - `agent-manager.test.ts` - Claude Code agent initialization (demonstrates test database usage)
+- `credential-manager.test.ts` - OAuth token expiration, credential schema validation
 - `prerequisites.test.ts` - Version comparison logic for update checking
 - `formatters.test.ts` - Date formatting utilities
 

--- a/packages/agents/claude-code/claude-bootstrap.sh
+++ b/packages/agents/claude-code/claude-bootstrap.sh
@@ -3,17 +3,24 @@ set -euo pipefail
 
 CONFIG="${HOME}/.claude.json"
 SETTINGS_DIR="${HOME}/.claude"
+CREDENTIALS_FILE="${SETTINGS_DIR}/.credentials.json"
 
 mkdir -p "$SETTINGS_DIR"
 
-# Optional: approve the current API key (last 20 chars) instead of "*"
-last20=""
-if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-  last20="${ANTHROPIC_API_KEY: -20}"
-fi
+if [ -n "${VIWO_OAUTH_CREDENTIALS:-}" ]; then
+  # OAuth mode: write pre-built JSON files directly
+  printf '%s' "$VIWO_OAUTH_CREDENTIALS" > "$CREDENTIALS_FILE"
+  chmod 600 "$CREDENTIALS_FILE"
 
-# Global config: onboarding + API key approval
-cat > "$CONFIG" <<EOF
+  printf '%s' "$VIWO_OAUTH_CONFIG" > "$CONFIG"
+
+  unset VIWO_OAUTH_CREDENTIALS
+  unset VIWO_OAUTH_CONFIG
+
+elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  # API key mode
+  last20="${ANTHROPIC_API_KEY: -20}"
+  cat > "$CONFIG" <<EOF
 {
   "hasCompletedOnboarding": true,
   "hasCompletedProjectOnboarding": true,
@@ -26,16 +33,10 @@ cat > "$CONFIG" <<EOF
 }
 EOF
 
-# Settings: default permission mode = bypassPermissions
-#cat > "${SETTINGS_DIR}/settings.json" <<'EOF'
-#{
-#  "$schema": "https://json.schemastore.org/claude-code-settings.json",
-#  "permissions": {
-#    "allow": [],
-#    "deny": [],
-#    "defaultMode": "bypassPermissions"
-#  }
-#}
-#EOF
+else
+  echo "Error: No authentication credentials provided" >&2
+  echo "Configure auth with 'viwo auth' (API key or Claude subscription)" >&2
+  exit 1
+fi
 
 exec "$@"

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,65 +1,119 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import * as clack from '@clack/prompts';
-import { ConfigManager } from '@viwo/core';
+import { ConfigManager, CredentialManager } from '@viwo/core';
 
-const PROVIDERS = [
+const AUTH_METHODS = [
     {
-        value: 'anthropic' as const,
-        label: 'Anthropic',
-        hint: 'Claude API key',
+        value: 'oauth' as const,
+        label: 'Use Claude subscription',
+        hint: 'Auto-detect from Claude Code login (Max, Pro, Teams)',
+    },
+    {
+        value: 'api-key' as const,
+        label: 'Use Anthropic API key',
+        hint: 'Enter an sk-ant-... key manually',
     },
 ];
 
+const configureOAuth = async (): Promise<void> => {
+    const spinner = clack.spinner();
+    spinner.start('Detecting Claude subscription credentials...');
+
+    const summary = await CredentialManager.getCredentialSummary();
+
+    if (!summary) {
+        spinner.stop('No Claude subscription detected.');
+        clack.log.error(
+            'Could not find Claude Code OAuth credentials.\n' +
+                '  Make sure you have Claude Code installed and logged in.\n' +
+                '  Run "claude" on your host to authenticate first.'
+        );
+        return;
+    }
+
+    spinner.stop('Claude subscription detected!');
+
+    clack.log.info(
+        [
+            `Email: ${chalk.cyan(summary.emailAddress)}`,
+            summary.organizationName ? `Organization: ${chalk.cyan(summary.organizationName)}` : null,
+            summary.subscriptionType ? `Subscription: ${chalk.cyan(summary.subscriptionType)}` : null,
+            `Token expires: ${chalk.cyan(summary.expiresAt.toLocaleString())}${summary.tokenExpired ? chalk.yellow(' (expired - will refresh automatically)') : ''}`,
+        ]
+            .filter(Boolean)
+            .join('\n')
+    );
+
+    const confirmed = await clack.confirm({
+        message: 'Use this subscription for VIWO sessions?',
+    });
+
+    if (clack.isCancel(confirmed) || !confirmed) {
+        clack.cancel('Operation cancelled.');
+        process.exit(0);
+    }
+
+    ConfigManager.setAuthMethod('oauth');
+    clack.log.success('Authentication method set to Claude subscription.');
+    clack.log.info('Credentials will be read from your Claude Code login at each session start.');
+};
+
+const configureApiKey = async (): Promise<void> => {
+    const apiKey = await clack.password({
+        message: 'Enter your Anthropic API key',
+        validate: (value) => {
+            if (!value || !value.trim()) {
+                return 'API key cannot be empty';
+            }
+            if (!value.startsWith('sk-ant-')) {
+                return 'Anthropic API keys should start with "sk-ant-"';
+            }
+        },
+    });
+
+    if (clack.isCancel(apiKey)) {
+        clack.cancel('Operation cancelled.');
+        process.exit(0);
+    }
+
+    const spinner = clack.spinner();
+    spinner.start('Saving API key...');
+
+    await ConfigManager.setApiKey({ provider: 'anthropic', key: apiKey });
+    ConfigManager.setAuthMethod('api-key');
+
+    spinner.stop('API key saved successfully!');
+};
+
 export const authCommand = new Command('auth')
-    .description('Configure API keys for AI providers')
+    .description('Configure authentication for AI providers')
     .action(async () => {
         try {
             clack.intro(chalk.bgCyan(' viwo auth '));
 
-            // Step 1: Select provider
-            const selectedProvider = await clack.select({
-                message: 'Select an API provider to configure',
-                options: PROVIDERS.map((provider) => ({
-                    label: provider.label,
-                    value: provider.value,
-                    hint: provider.hint,
+            const currentMethod = ConfigManager.getAuthMethod();
+            clack.log.info(`Current auth method: ${chalk.cyan(currentMethod)}`);
+
+            const selectedMethod = await clack.select({
+                message: 'Select authentication method',
+                options: AUTH_METHODS.map((method) => ({
+                    label: method.label,
+                    value: method.value,
+                    hint: method.hint,
                 })),
             });
 
-            if (clack.isCancel(selectedProvider)) {
+            if (clack.isCancel(selectedMethod)) {
                 clack.cancel('Operation cancelled.');
                 process.exit(0);
             }
 
-            // Step 2: Get API key with masked input
-            const apiKey = await clack.password({
-                message: `Enter your ${PROVIDERS.find((p) => p.value === selectedProvider)?.label} API key`,
-                validate: (value) => {
-                    if (!value || !value.trim()) {
-                        return 'API key cannot be empty';
-                    }
-                    if (selectedProvider === 'anthropic' && !value.startsWith('sk-ant-')) {
-                        return 'Anthropic API keys should start with "sk-ant-"';
-                    }
-                },
-            });
-
-            if (clack.isCancel(apiKey)) {
-                clack.cancel('Operation cancelled.');
-                process.exit(0);
+            if (selectedMethod === 'oauth') {
+                await configureOAuth();
+            } else {
+                await configureApiKey();
             }
-
-            // Step 3: Save the API key
-            const spinner = clack.spinner();
-            spinner.start('Saving API key...');
-
-            await ConfigManager.setApiKey({
-                provider: selectedProvider,
-                key: apiKey,
-            });
-
-            spinner.stop('API key saved successfully!');
 
             clack.outro(chalk.green('Authentication configured!'));
         } catch (error) {

--- a/packages/core/src/db-schemas/configuration.ts
+++ b/packages/core/src/db-schemas/configuration.ts
@@ -3,6 +3,7 @@ import { sqliteTable, integer, text } from 'drizzle-orm/sqlite-core';
 export const configurations = sqliteTable('configurations', {
     id: integer('id').primaryKey(),
     anthropicApiKey: text('anthropic_api_key'),
+    authMethod: text('auth_method'),
     preferredIde: text('preferred_ide'),
     worktreesStorageLocation: text('worktrees_storage_location'),
     createdAt: text('created_at'),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * as DockerManager from './managers/docker-manager';
 export * as AgentManager from './managers/agent-manager';
 export * as PortManager from './managers/port-manager';
 export * as ConfigManager from './managers/config-manager';
+export * as CredentialManager from './managers/credential-manager';
 export * as IDEManager from './managers/ide-manager';
 export * as ProjectConfigManager from './managers/project-config-manager';
 

--- a/packages/core/src/managers/__tests__/credential-manager.test.ts
+++ b/packages/core/src/managers/__tests__/credential-manager.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect } from 'bun:test';
+import { isOAuthTokenExpired } from '../credential-manager';
+import type { OAuthCredentials } from '../../types';
+import { OAuthCredentialsSchema, OAuthAccountInfoSchema } from '../../schemas';
+
+describe('credential-manager', () => {
+    describe('isOAuthTokenExpired', () => {
+        test('returns false when token has not expired', () => {
+            const credentials: OAuthCredentials = {
+                accessToken: 'sk-ant-oat01-test-token',
+                refreshToken: 'sk-ant-ort01-test-refresh',
+                expiresAt: Date.now() + 3600000,
+                scopes: ['user:inference'],
+            };
+
+            expect(isOAuthTokenExpired(credentials)).toBe(false);
+        });
+
+        test('returns true when token has expired', () => {
+            const credentials: OAuthCredentials = {
+                accessToken: 'sk-ant-oat01-test-token',
+                refreshToken: 'sk-ant-ort01-test-refresh',
+                expiresAt: Date.now() - 1000,
+                scopes: ['user:inference'],
+            };
+
+            expect(isOAuthTokenExpired(credentials)).toBe(true);
+        });
+
+        test('returns true when token expires exactly now', () => {
+            const credentials: OAuthCredentials = {
+                accessToken: 'sk-ant-oat01-test-token',
+                refreshToken: 'sk-ant-ort01-test-refresh',
+                expiresAt: Date.now(),
+                scopes: ['user:inference'],
+            };
+
+            expect(isOAuthTokenExpired(credentials)).toBe(true);
+        });
+    });
+
+    describe('OAuthCredentialsSchema', () => {
+        test('validates correct credentials', () => {
+            const valid = {
+                accessToken: 'sk-ant-oat01-test-token-value',
+                refreshToken: 'sk-ant-ort01-test-refresh-value',
+                expiresAt: 1774020540063,
+                scopes: ['user:inference', 'user:profile'],
+                subscriptionType: 'team',
+                rateLimitTier: 'default_claude_max_5x',
+            };
+
+            const result = OAuthCredentialsSchema.safeParse(valid);
+            expect(result.success).toBe(true);
+        });
+
+        test('rejects access token with wrong prefix', () => {
+            const invalid = {
+                accessToken: 'sk-ant-api03-wrong-prefix',
+                refreshToken: 'sk-ant-ort01-test-refresh-value',
+                expiresAt: 1774020540063,
+                scopes: ['user:inference'],
+            };
+
+            const result = OAuthCredentialsSchema.safeParse(invalid);
+            expect(result.success).toBe(false);
+        });
+
+        test('rejects refresh token with wrong prefix', () => {
+            const invalid = {
+                accessToken: 'sk-ant-oat01-test-token-value',
+                refreshToken: 'sk-ant-api03-wrong-prefix',
+                expiresAt: 1774020540063,
+                scopes: ['user:inference'],
+            };
+
+            const result = OAuthCredentialsSchema.safeParse(invalid);
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe('OAuthAccountInfoSchema', () => {
+        test('validates correct account info', () => {
+            const valid = {
+                accountUuid: '438de200-a809-46ad-8457-98fd640b822f',
+                emailAddress: 'user@example.com',
+                organizationUuid: 'f4216429-e76d-43c8-bc31-5f4dbb9d1d1d',
+                displayName: 'Test User',
+                organizationName: 'Test Org',
+            };
+
+            const result = OAuthAccountInfoSchema.safeParse(valid);
+            expect(result.success).toBe(true);
+        });
+
+        test('accepts account info without optional fields', () => {
+            const minimal = {
+                accountUuid: '438de200-a809-46ad-8457-98fd640b822f',
+                emailAddress: 'user@example.com',
+            };
+
+            const result = OAuthAccountInfoSchema.safeParse(minimal);
+            expect(result.success).toBe(true);
+        });
+    });
+});

--- a/packages/core/src/managers/agent-manager.ts
+++ b/packages/core/src/managers/agent-manager.ts
@@ -12,7 +12,8 @@ import {
     getContainerLogs,
     pullImage,
 } from './docker-manager';
-import { getApiKey } from './config-manager';
+import { getApiKey, getAuthMethod } from './config-manager';
+import { extractOAuthCredentials, extractOAuthAccountInfo } from './credential-manager';
 
 export interface InitializeAgentOptions {
     sessionId: number;
@@ -37,61 +38,52 @@ export const initializeAgent = async (options: InitializeAgentOptions): Promise<
 };
 
 const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<void> => {
-    const { sessionId, worktreePath, config } = options;
+    const authMethod = getAuthMethod();
 
-    // Check if Docker is running
-    await docker.checkDockerRunningOrThrow();
-
-    // Get API key from configuration
-    const apiKey = getApiKey({ provider: 'anthropic' });
-
-    if (!apiKey) {
-        throw new Error(
-            'Anthropic API key not configured. ' + 'Please run "viwo auth" to set up your API key.'
-        );
+    if (authMethod === 'oauth') {
+        await initializeClaudeCodeWithOAuth(options);
+    } else {
+        await initializeClaudeCodeWithApiKey(options);
     }
+};
 
-    // Check if Claude Code image exists
-    const imageExists = await checkImageExists({ image: CLAUDE_CODE_IMAGE });
-
-    if (!imageExists) {
-        await pullImage({ image: CLAUDE_CODE_IMAGE });
-        // throw new Error(
-        //     `Claude Code Docker image '${CLAUDE_CODE_IMAGE}' not found. ` +
-        //         `Please build the image first or ensure it's available locally.`
-        // );
-    }
-
-    // Generate container name
-    const containerName = `viwo-claude-${sessionId}-${Date.now()}`;
-
-    // Build the claude command
-    // The prompt will be passed as arguments to the claude CLI
+const buildClaudeCommand = (config: AgentConfig): string[] => {
     const command = ['claude', '--dangerously-skip-permissions', '--print', '--verbose'];
 
-    // Add model flag if specified
     if (config.model) {
         command.push('--model', config.model);
     }
 
-    // Add the prompt as the final argument
-    // Docker handles argument separation, so no manual quoting needed
     command.push(config.initialPrompt);
+    return command;
+};
 
-    // Create the container
+const startClaudeContainer = async (options: {
+    sessionId: number;
+    worktreePath: string;
+    config: AgentConfig;
+    env: Record<string, string>;
+}): Promise<void> => {
+    const { sessionId, worktreePath, config, env } = options;
+
+    const imageExists = await checkImageExists({ image: CLAUDE_CODE_IMAGE });
+    if (!imageExists) {
+        await pullImage({ image: CLAUDE_CODE_IMAGE });
+    }
+
+    const containerName = `viwo-claude-${sessionId}-${Date.now()}`;
+    const command = buildClaudeCommand(config);
+
     const containerInfo = await createContainer({
         name: containerName,
         image: CLAUDE_CODE_IMAGE,
         worktreePath,
         command,
-        env: {
-            ANTHROPIC_API_KEY: apiKey,
-        },
+        env,
         tty: true,
         openStdin: true,
     });
 
-    // Log initial prompt to chats table
     const initialChat: NewChat = {
         sessionId: sessionId.toString(),
         type: 'user',
@@ -100,10 +92,8 @@ const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<vo
     };
     db.insert(chats).values(initialChat).run();
 
-    // Start the container
     await startContainer({ containerId: containerInfo.id });
 
-    // Update session with container info and running status
     session.update({
         id: sessionId,
         updates: {
@@ -115,8 +105,6 @@ const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<vo
         },
     });
 
-    // Set up background log streaming to chats table
-    // This runs in the background and doesn't block the function return
     getContainerLogs(
         {
             containerId: containerInfo.id,
@@ -125,7 +113,6 @@ const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<vo
             stderr: true,
         },
         (logContent: string) => {
-            // Insert each log entry as an assistant message in the chats table
             const chatEntry: NewChat = {
                 sessionId: sessionId.toString(),
                 type: 'assistant',
@@ -134,7 +121,6 @@ const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<vo
             };
             db.insert(chats).values(chatEntry).run();
 
-            // Update last activity timestamp
             session.update({
                 id: sessionId,
                 updates: {
@@ -143,7 +129,6 @@ const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<vo
             });
         }
     ).catch((error) => {
-        // Log streaming error - update session with error status
         console.error(`Log streaming error for session ${sessionId}:`, error);
         session.update({
             id: sessionId,
@@ -153,9 +138,58 @@ const initializeClaudeCode = async (options: InitializeAgentOptions): Promise<vo
             },
         });
     });
+};
 
-    // Return immediately without waiting for container to finish
-    // The container will run in the background
+const initializeClaudeCodeWithApiKey = async (options: InitializeAgentOptions): Promise<void> => {
+    await docker.checkDockerRunningOrThrow();
+
+    const apiKey = getApiKey({ provider: 'anthropic' });
+    if (!apiKey) {
+        throw new Error(
+            'Anthropic API key not configured. Please run "viwo auth" to set up your API key.'
+        );
+    }
+
+    await startClaudeContainer({
+        sessionId: options.sessionId,
+        worktreePath: options.worktreePath,
+        config: options.config,
+        env: { ANTHROPIC_API_KEY: apiKey },
+    });
+};
+
+const initializeClaudeCodeWithOAuth = async (options: InitializeAgentOptions): Promise<void> => {
+    await docker.checkDockerRunningOrThrow();
+
+    const credentials = await extractOAuthCredentials();
+    if (!credentials) {
+        throw new Error(
+            'No Claude subscription credentials found. ' +
+                'Please log in with Claude Code first (run "claude" on your host), ' +
+                'or switch to API key auth with "viwo auth".'
+        );
+    }
+
+    const accountInfo = extractOAuthAccountInfo();
+    const claudeConfig = JSON.stringify({
+        hasCompletedOnboarding: true,
+        hasCompletedProjectOnboarding: true,
+        hasTrustDialogAccepted: true,
+        bypassPermissionsAccepted: true,
+        ...(accountInfo ? { oauthAccount: accountInfo } : {}),
+    });
+    const credentialsFile = JSON.stringify({ claudeAiOauth: credentials });
+
+    await startClaudeContainer({
+        sessionId: options.sessionId,
+        worktreePath: options.worktreePath,
+        config: options.config,
+        env: {
+            CLAUDE_CODE_OAUTH_TOKEN: credentials.accessToken,
+            VIWO_OAUTH_CREDENTIALS: credentialsFile,
+            VIWO_OAUTH_CONFIG: claudeConfig,
+        },
+    });
 };
 
 const initializeCline = async (_options: InitializeAgentOptions): Promise<void> => {

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -3,7 +3,7 @@ import { hostname, userInfo } from 'os';
 import { db } from '../db';
 import { configurations } from '../db-schemas';
 import { eq } from 'drizzle-orm';
-import type { IDEType } from '../types.js';
+import type { AuthMethod, IDEType } from '../types.js';
 import { expandTilde } from '../utils/paths.js';
 
 const ALGORITHM = 'aes-256-gcm';
@@ -257,12 +257,47 @@ export const deleteWorktreesStorageLocation = (): void => {
         .run();
 };
 
+export const setAuthMethod = (method: AuthMethod): void => {
+    const now = new Date().toISOString();
+    const existing = db.select().from(configurations).limit(1).all();
+
+    if (existing.length > 0) {
+        db.update(configurations)
+            .set({
+                authMethod: method,
+                updatedAt: now,
+            })
+            .where(eq(configurations.id, existing[0]!.id))
+            .run();
+    } else {
+        db.insert(configurations)
+            .values({
+                authMethod: method,
+                createdAt: now,
+                updatedAt: now,
+            })
+            .run();
+    }
+};
+
+export const getAuthMethod = (): AuthMethod => {
+    const config = db.select().from(configurations).limit(1).all();
+
+    if (config.length === 0) {
+        return 'api-key';
+    }
+
+    return (config[0]!.authMethod as AuthMethod) || 'api-key';
+};
+
 // Namespace export for consistency with other managers
 export const config = {
     setApiKey,
     getApiKey,
     hasApiKey,
     deleteApiKey,
+    setAuthMethod,
+    getAuthMethod,
     setPreferredIDE,
     getPreferredIDE,
     deletePreferredIDE,

--- a/packages/core/src/managers/credential-manager.ts
+++ b/packages/core/src/managers/credential-manager.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from 'node:fs';
+import { userInfo, homedir } from 'node:os';
+import path from 'path';
+import { OAuthCredentialsSchema, OAuthAccountInfoSchema } from '../schemas';
+import type { OAuthCredentials, OAuthAccountInfo } from '../types';
+
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+
+const extractFromMacKeychain = async (): Promise<OAuthCredentials | null> => {
+    const account = userInfo().username;
+
+    const proc = Bun.spawn(['security', 'find-generic-password', '-s', KEYCHAIN_SERVICE, '-a', account, '-w'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0 || !output.trim()) {
+        return null;
+    }
+
+    const parsed = JSON.parse(output.trim());
+    const oauthData = parsed.claudeAiOauth;
+
+    if (!oauthData) {
+        return null;
+    }
+
+    const result = OAuthCredentialsSchema.safeParse(oauthData);
+    return result.success ? result.data : null;
+};
+
+export const extractOAuthCredentials = async (): Promise<OAuthCredentials | null> => {
+    const platform = process.platform;
+
+    if (platform === 'darwin') {
+        return extractFromMacKeychain();
+    }
+
+    // Linux: try reading ~/.claude/.credentials.json directly
+    if (platform === 'linux') {
+        try {
+            const credPath = path.join(homedir(), '.claude', '.credentials.json');
+            const content = readFileSync(credPath, 'utf-8');
+            const parsed = JSON.parse(content);
+            const oauthData = parsed.claudeAiOauth;
+            if (!oauthData) return null;
+            const result = OAuthCredentialsSchema.safeParse(oauthData);
+            return result.success ? result.data : null;
+        } catch {
+            return null;
+        }
+    }
+
+    return null;
+};
+
+export const extractOAuthAccountInfo = (): OAuthAccountInfo | null => {
+    try {
+        const configPath = path.join(homedir(), '.claude.json');
+        const content = readFileSync(configPath, 'utf-8');
+        const parsed = JSON.parse(content);
+        const accountData = parsed.oauthAccount;
+
+        if (!accountData) {
+            return null;
+        }
+
+        const result = OAuthAccountInfoSchema.safeParse(accountData);
+        return result.success ? result.data : null;
+    } catch {
+        return null;
+    }
+};
+
+export const hasOAuthCredentials = async (): Promise<boolean> => {
+    const credentials = await extractOAuthCredentials();
+    return credentials !== null;
+};
+
+export const isOAuthTokenExpired = (credentials: OAuthCredentials): boolean => {
+    return Date.now() >= credentials.expiresAt;
+};
+
+export interface CredentialSummary {
+    emailAddress: string;
+    organizationName?: string;
+    subscriptionType?: string;
+    rateLimitTier?: string;
+    tokenExpired: boolean;
+    expiresAt: Date;
+}
+
+export const getCredentialSummary = async (): Promise<CredentialSummary | null> => {
+    const credentials = await extractOAuthCredentials();
+    const accountInfo = extractOAuthAccountInfo();
+
+    if (!credentials || !accountInfo) {
+        return null;
+    }
+
+    return {
+        emailAddress: accountInfo.emailAddress,
+        organizationName: accountInfo.organizationName,
+        subscriptionType: credentials.subscriptionType,
+        rateLimitTier: credentials.rateLimitTier,
+        tokenExpired: isOAuthTokenExpired(credentials),
+        expiresAt: new Date(credentials.expiresAt),
+    };
+};
+
+export const credential = {
+    extractOAuthCredentials,
+    extractOAuthAccountInfo,
+    hasOAuthCredentials,
+    isOAuthTokenExpired,
+    getCredentialSummary,
+};

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -121,5 +121,12 @@ export const migrations: Migration[] = [
         up: `
             ALTER TABLE \`sessions\` ADD \`containerOutput\` text;
         `
+    },
+    {
+        version: 8,
+        name: 'gentle_oauth_support',
+        up: `
+            ALTER TABLE \`configurations\` ADD \`auth_method\` text DEFAULT 'api-key';
+        `
     }
 ];

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -127,3 +127,27 @@ export const ProjectConfigSchema = z.object({
     postInstall: z.array(z.string()).optional(),
 });
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
+
+/**
+ * Authentication schemas
+ */
+export const AuthMethodSchema = z.enum(['api-key', 'oauth']);
+
+export const OAuthCredentialsSchema = z.object({
+    accessToken: z.string().startsWith('sk-ant-oat'),
+    refreshToken: z.string().startsWith('sk-ant-ort'),
+    expiresAt: z.number(),
+    scopes: z.array(z.string()),
+    subscriptionType: z.string().optional(),
+    rateLimitTier: z.string().optional(),
+});
+
+export const OAuthAccountInfoSchema = z.object({
+    accountUuid: z.string(),
+    emailAddress: z.string(),
+    organizationUuid: z.string().optional(),
+    hasExtraUsageEnabled: z.boolean().optional(),
+    billingType: z.string().optional(),
+    displayName: z.string().optional(),
+    organizationName: z.string().optional(),
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,3 +39,33 @@ export interface IDEInfo {
     command: string;
     available: boolean;
 }
+
+/**
+ * Authentication method for Claude Code
+ */
+export type AuthMethod = 'api-key' | 'oauth';
+
+/**
+ * OAuth credentials from Claude Code's credential store
+ */
+export interface OAuthCredentials {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt: number;
+    scopes: string[];
+    subscriptionType?: string;
+    rateLimitTier?: string;
+}
+
+/**
+ * OAuth account metadata from ~/.claude.json
+ */
+export interface OAuthAccountInfo {
+    accountUuid: string;
+    emailAddress: string;
+    organizationUuid?: string;
+    hasExtraUsageEnabled?: boolean;
+    billingType?: string;
+    displayName?: string;
+    organizationName?: string;
+}


### PR DESCRIPTION
Allow users with Claude Max, Pro, or Teams subscriptions to authenticate without an API key. OAuth credentials are auto-detected from the host's Claude Code installation (macOS Keychain) and injected into Docker containers via the bootstrap script writing ~/.claude/.credentials.json.

- Add credential-manager for host OAuth credential extraction
- Extend config-manager with auth method preference (api-key | oauth)
- Refactor agent-manager to branch on auth method
- Redesign viwo auth CLI with subscription auto-detect option
- Update bootstrap script to handle both OAuth and API key modes
- Add DB migration for auth_method column
- Add types, Zod schemas, and tests for OAuth credentials