### PR TITLE
Add configurable Claude model preference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 - `agent-manager.ts` - AI agent initialization with automatic container lifecycle management (only Claude Code implemented)
 - `repository-manager.ts` - Repository CRUD
 - `port-manager.ts` - Port allocation via get-port
-- `config-manager.ts` - Configuration management (API keys, IDE preferences, worktrees storage location)
+- `config-manager.ts` - Configuration management (API keys, IDE preferences, model preference, worktrees storage location)
 - `ide-manager.ts` - IDE detection and launching
 - `project-config-manager.ts` - Project configuration file detection and parsing (viwo.yml/viwo.yaml)
 
@@ -102,6 +102,7 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 - **Configuration storage**: The `configurations` table stores user preferences including:
   - API keys (encrypted)
   - Preferred IDE
+  - Preferred Claude model (sonnet, opus, haiku)
   - Worktrees storage location (supports absolute or relative paths)
 - **Session storage**: The `sessions` table stores worktree session details including:
   - Container output (`containerOutput` field) - Full stdout/stderr captured when session completes or errors
@@ -206,6 +207,10 @@ Commands in `packages/cli/src/commands/`:
   - Interactive list showing available IDEs on the system
   - Displays current default IDE setting
   - Allows changing to a different IDE or removing the default (prompts each time)
+- `config model` - Configure preferred Claude model
+  - Interactive list with Sonnet, Opus, Haiku options
+  - Displays current model setting (default: Sonnet)
+  - Used by `start` flow when initializing agents
 - `config worktrees` - Configure worktrees storage location
   - View current worktrees storage location (custom or default)
   - Set custom location (absolute or relative to app data directory)

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { select, input } from '@inquirer/prompts';
 import chalk from 'chalk';
-import { IDEManager, ConfigManager, type IDEType, type IDEInfo, AppPaths } from '@viwo/core';
+import { IDEManager, ConfigManager, type IDEType, type IDEInfo, type ModelType, AppPaths } from '@viwo/core';
 import { isAbsolute } from 'path';
 import { preflightChecksOrExit } from '../utils/prerequisites';
 
@@ -342,7 +342,127 @@ const worktreesCommand = new Command('worktrees')
 		}
 	});
 
+const MODEL_DISPLAY_NAMES: Record<ModelType, string> = {
+	sonnet: 'Sonnet',
+	opus: 'Opus',
+	haiku: 'Haiku',
+};
+
+const runModelConfig = async (): Promise<void> => {
+	try {
+		await preflightChecksOrExit({ requireGit: false, requireDocker: false });
+
+		console.clear();
+		console.log();
+		console.log(chalk.bold.cyan('Model Configuration'));
+		console.log(chalk.gray('═'.repeat(70)));
+		console.log();
+
+		const currentModel = ConfigManager.getPreferredModel();
+
+		console.log(chalk.bold('Current Model'));
+		if (currentModel) {
+			console.log(chalk.gray('  ') + chalk.green(MODEL_DISPLAY_NAMES[currentModel]));
+		} else {
+			console.log(chalk.gray('  ') + chalk.yellow('Default: ') + chalk.white('Sonnet'));
+		}
+		console.log();
+		console.log(chalk.gray('═'.repeat(70)));
+		console.log();
+
+		const models: ModelType[] = ['sonnet', 'opus', 'haiku'];
+
+		const choices = models.map((model) => ({
+			name:
+				model === currentModel
+					? `${MODEL_DISPLAY_NAMES[model]} ${chalk.green('(current)')}`
+					: MODEL_DISPLAY_NAMES[model],
+			value: model as string,
+		}));
+
+		choices.push({
+			name: chalk.gray('─'.repeat(70)),
+			value: '__separator__',
+		});
+
+		choices.push({
+			name: chalk.yellow('Reset to default (Sonnet)'),
+			value: '__reset__',
+		});
+
+		choices.push({
+			name: chalk.gray('❌ Cancel'),
+			value: '__cancel__',
+		});
+
+		const selection = await select<string>({
+			message: 'Select your preferred model:',
+			choices,
+			pageSize: 10,
+		});
+
+		if (selection === '__cancel__' || selection === '__separator__') {
+			console.log();
+			console.log(chalk.gray('No changes made'));
+			console.log();
+			return;
+		}
+
+		if (selection === '__reset__') {
+			if (!currentModel) {
+				console.log();
+				console.log(chalk.yellow('Already using default model'));
+				console.log();
+				return;
+			}
+
+			ConfigManager.deletePreferredModel();
+			console.log();
+			console.log(chalk.green('✓ Model reset to default (Sonnet)'));
+			console.log();
+			return;
+		}
+
+		const selectedModel = selection as ModelType;
+
+		if (selectedModel === currentModel) {
+			console.log();
+			console.log(chalk.yellow(`${MODEL_DISPLAY_NAMES[selectedModel]} is already your preferred model`));
+			console.log();
+			return;
+		}
+
+		ConfigManager.setPreferredModel(selectedModel);
+		console.log();
+		console.log(chalk.green(`✓ Set ${MODEL_DISPLAY_NAMES[selectedModel]} as preferred model`));
+		console.log();
+	} catch (error) {
+		if ((error as any).name === 'ExitPromptError') {
+			console.log();
+			console.log(chalk.gray('Operation cancelled'));
+			console.log();
+			process.exit(0);
+		}
+		throw error;
+	}
+};
+
+const modelCommand = new Command('model')
+	.description('Configure preferred Claude model')
+	.action(async () => {
+		try {
+			await runModelConfig();
+		} catch (error) {
+			console.error(
+				chalk.red('Configuration failed:'),
+				error instanceof Error ? error.message : String(error)
+			);
+			process.exit(1);
+		}
+	});
+
 export const configCommand = new Command('config')
 	.description('Manage VIWO configuration')
 	.addCommand(ideCommand)
-	.addCommand(worktreesCommand);
+	.addCommand(worktreesCommand)
+	.addCommand(modelCommand);

--- a/packages/core/src/db-schemas/configuration.ts
+++ b/packages/core/src/db-schemas/configuration.ts
@@ -5,6 +5,7 @@ export const configurations = sqliteTable('configurations', {
     anthropicApiKey: text('anthropic_api_key'),
     preferredIde: text('preferred_ide'),
     worktreesStorageLocation: text('worktrees_storage_location'),
+    modelPreference: text('model_preference'),
     createdAt: text('created_at'),
     updatedAt: text('updated_at'),
 });

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -3,7 +3,7 @@ import { hostname, userInfo } from 'os';
 import { db } from '../db';
 import { configurations } from '../db-schemas';
 import { eq } from 'drizzle-orm';
-import type { IDEType } from '../types.js';
+import type { IDEType, ModelType } from '../types.js';
 import { expandTilde } from '../utils/paths.js';
 
 const ALGORITHM = 'aes-256-gcm';
@@ -204,6 +204,55 @@ export const deletePreferredIDE = (): void => {
         .run();
 };
 
+export const setPreferredModel = (model: ModelType): void => {
+    const now = new Date().toISOString();
+    const existing = db.select().from(configurations).limit(1).all();
+
+    if (existing.length > 0) {
+        db.update(configurations)
+            .set({
+                modelPreference: model,
+                updatedAt: now,
+            })
+            .where(eq(configurations.id, existing[0]!.id))
+            .run();
+    } else {
+        db.insert(configurations)
+            .values({
+                modelPreference: model,
+                createdAt: now,
+                updatedAt: now,
+            })
+            .run();
+    }
+};
+
+export const getPreferredModel = (): ModelType | null => {
+    const config = db.select().from(configurations).limit(1).all();
+
+    if (config.length === 0) {
+        return null;
+    }
+
+    return (config[0]!.modelPreference as ModelType) || null;
+};
+
+export const deletePreferredModel = (): void => {
+    const config = db.select().from(configurations).limit(1).get();
+
+    if (!config) {
+        return;
+    }
+
+    db.update(configurations)
+        .set({
+            modelPreference: null,
+            updatedAt: new Date().toISOString(),
+        })
+        .where(eq(configurations.id, config.id))
+        .run();
+};
+
 export const setWorktreesStorageLocation = (location: string): void => {
     const now = new Date().toISOString();
     // Expand tilde (~) to home directory before storing
@@ -266,6 +315,9 @@ export const config = {
     setPreferredIDE,
     getPreferredIDE,
     deletePreferredIDE,
+    setPreferredModel,
+    getPreferredModel,
+    deletePreferredModel,
     setWorktreesStorageLocation,
     getWorktreesStorageLocation,
     deleteWorktreesStorageLocation,

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -121,5 +121,12 @@ export const migrations: Migration[] = [
         up: `
             ALTER TABLE \`sessions\` ADD \`containerOutput\` text;
         `
+    },
+    {
+        version: 8,
+        name: 'gentle_star_lord',
+        up: `
+            ALTER TABLE \`configurations\` ADD \`model_preference\` text;
+        `
     }
 ];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,6 +12,11 @@ export enum SessionStatus {
 }
 
 /**
+ * Supported Claude model types
+ */
+export type ModelType = 'sonnet' | 'opus' | 'haiku';
+
+/**
  * Supported IDE types
  */
 export type IDEType =

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -27,6 +27,7 @@ import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { sessionToWorktreeSession } from './utils/types';
 import { loadProjectConfig } from './managers/project-config-manager';
+import { getPreferredModel } from './managers/config-manager';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -148,7 +149,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                     config: {
                         initialPrompt: validatedOptions.prompt,
                         type: 'claude-code',
-                        model: 'sonnet',
+                        model: getPreferredModel() ?? 'sonnet',
                     },
                 });
 


### PR DESCRIPTION
## Summary
- Adds `ModelType` (`sonnet | opus | haiku`) to core types
- Adds `model_preference` column to configurations table (migration v8)
- Adds `set/get/deletePreferredModel` to config manager
- Adds `viwo config model` CLI command with interactive selection
- Uses stored model preference when starting agent sessions (falls back to Sonnet)

## Test plan
- [ ] Run `viwo config model` and select a model
- [ ] Verify selection persists by running `viwo config model` again (shows current)
- [ ] Test reset to default option
- [ ] Run `viwo start` and verify the preferred model is used in agent config
- [ ] Test cancel flow exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)