### PR TITLE
Fix postInstall hooks missing user shell environment

### DIFF
--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -123,11 +123,15 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                 const projectConfig = loadProjectConfig({ repoPath });
 
                 if (projectConfig?.postInstall && projectConfig.postInstall.length > 0) {
+                    const userShell = process.env.SHELL || '/bin/sh';
+
                     for (const command of projectConfig.postInstall) {
                         try {
                             await execAsync(command, {
                                 cwd: worktreePath,
+                                shell: userShell,
                                 env: {
+                                    ...process.env,
                                     VIWO_WORKTREE_PATH: worktreePath,
                                 },
                             });


### PR DESCRIPTION
## Summary
- Inherit `process.env` so post-install commands have access to `PATH`, `HOME`, and other environment variables
- Use the user's default shell (`$SHELL`) to execute commands, ensuring CLIs installed via shell profiles (e.g. `pnpm`, `nvm`) are available

Closes #61

## Test plan
- [x] Add a `viwo.yml` with `postInstall: ["pnpm install"]` and verify it works
- [x] Verify on macOS/Linux with zsh and bash shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)