### PR TITLE
feat: add configurable Claude model preference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 - `agent-manager.ts` - AI agent initialization with automatic container lifecycle management (only Claude Code implemented)
 - `repository-manager.ts` - Repository CRUD
 - `port-manager.ts` - Port allocation via get-port
-- `config-manager.ts` - Configuration management (API keys, auth method, IDE preferences, worktrees storage location)
+- `config-manager.ts` - Configuration management (API keys, auth method, IDE preferences, model preference, worktrees storage location)
 - `credential-manager.ts` - OAuth credential extraction from host system (macOS Keychain, Linux credential files)
 - `ide-manager.ts` - IDE detection and launching
 - `project-config-manager.ts` - Project configuration file detection and parsing (viwo.yml/viwo.yaml)
@@ -104,6 +104,7 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
   - API keys (encrypted)
   - Auth method (`'api-key'` or `'oauth'`)
   - Preferred IDE
+  - Preferred Claude model (`'sonnet'`, `'opus'`, or `'haiku'` — defaults to Sonnet)
   - Worktrees storage location (supports absolute or relative paths)
 - **Session storage**: The `sessions` table stores worktree session details including:
   - Container output (`containerOutput` field) - Full stdout/stderr captured when session completes or errors
@@ -223,6 +224,7 @@ Commands in `packages/cli/src/commands/`:
   - OAuth mode detects credentials from host's Claude Code installation
   - Displays subscription details (email, org, expiry) for confirmation
 - `repo` - Repository management (list, add, delete)
+- `config model` - Configure preferred Claude model (sonnet, opus, haiku)
 - `config ide` - Configure default IDE preference
   - Interactive list showing available IDEs on the system
   - Displays current default IDE setting

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { select, input, password } from '@inquirer/prompts';
 import chalk from 'chalk';
-import { IDEManager, ConfigManager, type IDEType, type IDEInfo, AppPaths } from '@viwo/core';
+import { IDEManager, ConfigManager, type IDEType, type IDEInfo, type ModelType, AppPaths } from '@viwo/core';
 import { isAbsolute } from 'path';
 import { preflightChecksOrExit } from '../utils/prerequisites';
 
@@ -20,6 +20,17 @@ const getCurrentWorktreesSummary = (): string => {
 const getCurrentAuthSummary = (): string => {
 	const hasKey = ConfigManager.hasApiKey({ provider: 'anthropic' });
 	return hasKey ? chalk.green('configured') : chalk.gray('not set');
+};
+
+const MODEL_INFO: Record<ModelType, { name: string; hint: string }> = {
+	opus: { name: 'Claude Opus', hint: 'Most capable, slowest' },
+	sonnet: { name: 'Claude Sonnet', hint: 'Balanced speed and intelligence' },
+	haiku: { name: 'Claude Haiku', hint: 'Fastest, least capable' },
+};
+
+const getCurrentModelSummary = (): string => {
+	const pref = ConfigManager.getPreferredModel();
+	return pref ? MODEL_INFO[pref].name : chalk.gray('default (Sonnet)');
 };
 
 // ─── IDE configuration flow ─────────────────────────────────────────────────
@@ -268,6 +279,92 @@ const runWorktreesLocationConfig = async (): Promise<void> => {
 	}
 };
 
+// ─── Model preference configuration flow ──────────────────────────────────
+
+const MODEL_CHOICES: ModelType[] = ['opus', 'sonnet', 'haiku'];
+
+const runModelConfig = async (): Promise<void> => {
+	console.clear();
+	console.log();
+	console.log(chalk.bold.cyan('Model Preference'));
+	console.log(chalk.gray('─'.repeat(50)));
+	console.log();
+
+	const currentPreference = ConfigManager.getPreferredModel();
+
+	console.log(chalk.bold('Current Model'));
+	if (currentPreference) {
+		console.log(
+			chalk.gray('  ') +
+				chalk.green(MODEL_INFO[currentPreference].name) +
+				chalk.gray(` (${currentPreference})`)
+		);
+	} else {
+		console.log(chalk.gray('  Default: ') + chalk.white('Claude Sonnet'));
+	}
+	console.log();
+
+	const choices = MODEL_CHOICES.map((model) => ({
+		name:
+			model === currentPreference
+				? `${MODEL_INFO[model].name} ${chalk.gray(`— ${MODEL_INFO[model].hint}`)} ${chalk.green('(current)')}`
+				: `${MODEL_INFO[model].name} ${chalk.gray(`— ${MODEL_INFO[model].hint}`)}`,
+		value: model,
+	}));
+
+	choices.push({
+		name: chalk.gray('─'.repeat(50)),
+		value: '__separator__' as ModelType,
+	});
+
+	choices.push({
+		name: chalk.yellow('Reset to default (Sonnet)'),
+		value: '__remove__' as ModelType,
+	});
+
+	choices.push({
+		name: chalk.gray('Cancel'),
+		value: '__cancel__' as ModelType,
+	});
+
+	const selection = await select<ModelType>({
+		message: 'Select your preferred model:',
+		choices,
+		pageSize: 10,
+	});
+
+	if (selection === ('__cancel__' as string) || selection === ('__separator__' as string)) {
+		console.log(chalk.gray('No changes made'));
+		console.log();
+		return;
+	}
+
+	if (selection === ('__remove__' as string)) {
+		if (!currentPreference) {
+			console.log(chalk.yellow('Already using default (Sonnet)'));
+			console.log();
+			return;
+		}
+
+		ConfigManager.deletePreferredModel();
+		console.log(chalk.green('✓ Model preference reset to default (Sonnet)'));
+		console.log();
+		return;
+	}
+
+	if (selection === currentPreference) {
+		console.log(
+			chalk.yellow(`${MODEL_INFO[selection].name} is already your preferred model`)
+		);
+		console.log();
+		return;
+	}
+
+	ConfigManager.setPreferredModel(selection);
+	console.log(chalk.green(`✓ Set ${MODEL_INFO[selection].name} as preferred model`));
+	console.log();
+};
+
 // ─── Authentication configuration flow ──────────────────────────────────────
 
 const PROVIDERS = [
@@ -357,6 +454,10 @@ const runConfigMenu = async (): Promise<void> => {
 					value: 'worktrees',
 				},
 				{
+					name: `Model preference        ${chalk.gray(`(${getCurrentModelSummary()})`)}`,
+					value: 'model',
+				},
+				{
 					name: `Authentication          ${chalk.gray(`(${getCurrentAuthSummary()})`)}`,
 					value: 'auth',
 				},
@@ -373,6 +474,9 @@ const runConfigMenu = async (): Promise<void> => {
 				break;
 			case 'worktrees':
 				await runWorktreesLocationConfig();
+				break;
+			case 'model':
+				await runModelConfig();
 				break;
 			case 'auth':
 				await runAuthConfig();
@@ -424,6 +528,25 @@ const worktreesCommand = new Command('worktrees')
 		}
 	});
 
+const modelCommand = new Command('model')
+	.description('Configure preferred Claude model')
+	.action(async () => {
+		try {
+			await preflightChecksOrExit({ requireGit: false, requireDocker: false });
+			await runModelConfig();
+		} catch (error) {
+			if ((error as any).name === 'ExitPromptError') {
+				console.log(chalk.gray('Operation cancelled'));
+				process.exit(0);
+			}
+			console.error(
+				chalk.red('Configuration failed:'),
+				error instanceof Error ? error.message : String(error)
+			);
+			process.exit(1);
+		}
+	});
+
 const authConfigCommand = new Command('auth')
 	.description('Configure API key authentication')
 	.action(async () => {
@@ -447,6 +570,7 @@ export const configCommand = new Command('config')
 	.description('Manage VIWO configuration')
 	.addCommand(ideCommand)
 	.addCommand(worktreesCommand)
+	.addCommand(modelCommand)
 	.addCommand(authConfigCommand)
 	.action(async () => {
 		try {

--- a/packages/core/src/db-schemas/configuration.ts
+++ b/packages/core/src/db-schemas/configuration.ts
@@ -6,6 +6,7 @@ export const configurations = sqliteTable('configurations', {
     authMethod: text('auth_method'),
     preferredIde: text('preferred_ide'),
     worktreesStorageLocation: text('worktrees_storage_location'),
+    preferredModel: text('preferred_model'),
     createdAt: text('created_at'),
     updatedAt: text('updated_at'),
 });

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -3,7 +3,7 @@ import { hostname, userInfo } from 'os';
 import { db } from '../db';
 import { configurations } from '../db-schemas';
 import { eq } from 'drizzle-orm';
-import type { AuthMethod, IDEType } from '../types.js';
+import type { AuthMethod, IDEType, ModelType } from '../types.js';
 import { expandTilde } from '../utils/paths.js';
 
 const ALGORITHM = 'aes-256-gcm';
@@ -280,6 +280,55 @@ export const setAuthMethod = (method: AuthMethod): void => {
     }
 };
 
+export const setPreferredModel = (model: ModelType): void => {
+    const now = new Date().toISOString();
+    const existing = db.select().from(configurations).limit(1).all();
+
+    if (existing.length > 0) {
+        db.update(configurations)
+            .set({
+                preferredModel: model,
+                updatedAt: now,
+            })
+            .where(eq(configurations.id, existing[0]!.id))
+            .run();
+    } else {
+        db.insert(configurations)
+            .values({
+                preferredModel: model,
+                createdAt: now,
+                updatedAt: now,
+            })
+            .run();
+    }
+};
+
+export const getPreferredModel = (): ModelType | null => {
+    const config = db.select().from(configurations).limit(1).all();
+
+    if (config.length === 0) {
+        return null;
+    }
+
+    return (config[0]!.preferredModel as ModelType) || null;
+};
+
+export const deletePreferredModel = (): void => {
+    const config = db.select().from(configurations).limit(1).get();
+
+    if (!config) {
+        return;
+    }
+
+    db.update(configurations)
+        .set({
+            preferredModel: null,
+            updatedAt: new Date().toISOString(),
+        })
+        .where(eq(configurations.id, config.id))
+        .run();
+};
+
 export const getAuthMethod = (): AuthMethod => {
     const config = db.select().from(configurations).limit(1).all();
 
@@ -301,6 +350,9 @@ export const config = {
     setPreferredIDE,
     getPreferredIDE,
     deletePreferredIDE,
+    setPreferredModel,
+    getPreferredModel,
+    deletePreferredModel,
     setWorktreesStorageLocation,
     getWorktreesStorageLocation,
     deleteWorktreesStorageLocation,

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -128,5 +128,12 @@ export const migrations: Migration[] = [
         up: `
             ALTER TABLE \`configurations\` ADD \`auth_method\` text DEFAULT 'api-key';
         `
+    },
+    {
+        version: 9,
+        name: 'model_preference',
+        up: `
+            ALTER TABLE \`configurations\` ADD \`preferred_model\` text;
+        `
     }
 ];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -46,6 +46,11 @@ export interface IDEInfo {
 export type AuthMethod = 'api-key' | 'oauth';
 
 /**
+ * Supported Claude model types
+ */
+export type ModelType = 'sonnet' | 'opus' | 'haiku';
+
+/**
  * OAuth credentials from Claude Code's credential store
  */
 export interface OAuthCredentials {

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -27,6 +27,7 @@ import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { sessionToWorktreeSession } from './utils/types';
 import { loadProjectConfig } from './managers/project-config-manager';
+import { getPreferredModel } from './managers/config-manager';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -152,7 +153,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                     config: {
                         initialPrompt: validatedOptions.prompt,
                         type: 'claude-code',
-                        model: 'sonnet',
+                        model: getPreferredModel() ?? 'sonnet',
                     },
                 });
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
# Add Configurable Claude Model Preference

This pull request introduces the ability for users to configure their preferred Claude model for AI agent sessions, providing flexibility in balancing speed and capability based on their specific needs.

## Changes

**New Feature: Model Preference Configuration**

- Added support for three Claude model options:
  - **Opus**: Most capable, slowest
  - **Sonnet**: Balanced speed and intelligence (default)
  - **Haiku**: Fastest, least capable

**Configuration Management**

- Extended database schema with `preferredModel` field in the configurations table
- Implemented configuration methods to set, retrieve, and reset model preference
- Added database migration (version 9) for the new model preference field

**CLI Enhancement**

- Added new `viwo config model` command with interactive selection menu
- Displays current model preference with descriptive hints for each option
- Allows users to reset to the default (Sonnet) model
- Shows visual indicators for the currently selected model

**Integration**

- Modified agent initialization to use the user's preferred model instead of hardcoded Sonnet
- Maintains Sonnet as the default when no preference is configured

**Documentation**

- Updated architecture documentation to reflect the new configuration option
- Added model preference to the list of managed configuration settings

This feature enables users to optimize their AI agent performance based on their specific requirements, whether they prioritize speed (Haiku), capability (Opus), or a balance of both (Sonnet).
<!-- kody-pr-summary:end -->