### PR TITLE
feat: store Claude Code version in session

### DIFF
--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -27,6 +27,9 @@ const displaySessionDetails = async (session: WorktreeSession) => {
     console.log();
     console.log(chalk.bold('Agent'));
     console.log(chalk.gray('  Type:            '), session.agent.type);
+    if (session.claudeCodeVersion) {
+        console.log(chalk.gray('  Version:         '), session.claudeCodeVersion);
+    }
     console.log(chalk.gray('  Prompt:          '), session.agent.initialPrompt);
     console.log();
 

--- a/packages/core/drizzle/0009_careful_rumiko_fujikawa.sql
+++ b/packages/core/drizzle/0009_careful_rumiko_fujikawa.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` ADD `claudeCodeVersion` text;

--- a/packages/core/drizzle/meta/0009_snapshot.json
+++ b/packages/core/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,306 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fd786e82-c4b9-49f8-bb61-568250d53e16",
+  "prevId": "1d986ac2-b879-44a9-b489-79a110fff92d",
+  "tables": {
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repoId": {
+          "name": "repoId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gitWorktreeName": {
+          "name": "gitWorktreeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerName": {
+          "name": "containerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerId": {
+          "name": "containerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerImage": {
+          "name": "containerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'initializing'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerOutput": {
+          "name": "containerOutput",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claudeCodeVersion": {
+          "name": "claudeCodeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "lastActivity": {
+          "name": "lastActivity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "configurations": {
+      "name": "configurations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_ide": {
+          "name": "preferred_ide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktrees_storage_location": {
+          "name": "worktrees_storage_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_model": {
+          "name": "preferred_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1775254281347,
       "tag": "0008_youthful_warlock",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1775683176205,
+      "tag": "0009_careful_rumiko_fujikawa",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db-schemas/session.ts
+++ b/packages/core/src/db-schemas/session.ts
@@ -15,6 +15,7 @@ export const sessions = sqliteTable('sessions', {
     status: text('status').default('initializing'),
     error: text('error'),
     containerOutput: text('containerOutput'),
+    claudeCodeVersion: text('claudeCodeVersion'),
     createdAt: text('createdAt').default(sql`(CURRENT_TIMESTAMP)`),
     lastActivity: text('lastActivity').default(sql`(CURRENT_TIMESTAMP)`),
 });

--- a/packages/core/src/managers/agent-manager.ts
+++ b/packages/core/src/managers/agent-manager.ts
@@ -5,6 +5,7 @@ import { session } from './session-manager';
 import {
     docker,
     CLAUDE_CODE_IMAGE,
+    CLAUDE_CODE_VERSION,
     checkImageExists,
     createContainer,
     startContainer,
@@ -111,6 +112,7 @@ const startClaudeContainer = async (options: {
             containerId: containerInfo.id,
             containerName: containerInfo.name,
             containerImage: CLAUDE_CODE_IMAGE,
+            claudeCodeVersion: CLAUDE_CODE_VERSION,
             status: SessionStatus.RUNNING,
             lastActivity: new Date().toISOString(),
         },
@@ -222,4 +224,3 @@ const initializeCursor = async (
 ): Promise<InitializeAgentResult> => {
     throw new Error('Cursor support not yet implemented');
 };
-

--- a/packages/core/src/managers/docker-manager.ts
+++ b/packages/core/src/managers/docker-manager.ts
@@ -41,6 +41,9 @@ const dockerSdk = new Docker(getDockerConfig());
 // Default Claude Code image name
 export const CLAUDE_CODE_IMAGE = 'overseedai/viwo-claude-code:1.2.0';
 
+// Claude Code CLI version installed in the image
+export const CLAUDE_CODE_VERSION = '2.1.96';
+
 export const isDockerRunning = async (): Promise<boolean> => {
     try {
         await dockerSdk.ping();
@@ -529,9 +532,10 @@ export const syncDockerState = async (): Promise<SyncDockerStateResult> => {
                     }
                 } else {
                     // No agent state — fall back to container exit code
-                    newStatus = containerInfo.exitCode === 0
-                        ? SessionStatus.COMPLETED
-                        : SessionStatus.ERROR;
+                    newStatus =
+                        containerInfo.exitCode === 0
+                            ? SessionStatus.COMPLETED
+                            : SessionStatus.ERROR;
                     reason = `Container exited with code ${containerInfo.exitCode}`;
                 }
             } else if (containerInfo.status === 'error') {
@@ -674,4 +678,5 @@ export const docker = {
     generateContainerName,
     readAgentState,
     CLAUDE_CODE_IMAGE,
+    CLAUDE_CODE_VERSION,
 };

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -137,4 +137,11 @@ export const migrations: Migration[] = [
             ALTER TABLE \`configurations\` ADD \`preferred_model\` text;
         `,
     },
+    {
+        version: 10,
+        name: 'careful_rumiko_fujikawa',
+        up: `
+            ALTER TABLE \`sessions\` ADD \`claudeCodeVersion\` text;
+        `,
+    },
 ];

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -72,6 +72,7 @@ export const WorktreeSessionSchema = z.object({
     error: z.string().optional(),
     containerOutput: z.string().optional(),
     containerName: z.string().optional(),
+    claudeCodeVersion: z.string().optional(),
     agentStatus: AgentStatusSchema.optional(),
     agentStateTimestamp: z.date().optional(),
 });

--- a/packages/core/src/utils/__tests__/types.test.ts
+++ b/packages/core/src/utils/__tests__/types.test.ts
@@ -39,6 +39,7 @@ describe('sessionToWorktreeSession', () => {
             createdAt: '2025-11-24 10:30:45',
             lastActivity: '2025-11-24 12:15:30',
             containerOutput: null,
+            claudeCodeVersion: null,
         };
 
         const result = sessionToWorktreeSession(dbSession);
@@ -79,6 +80,7 @@ describe('sessionToWorktreeSession', () => {
             createdAt: null,
             lastActivity: null,
             containerOutput: null,
+            claudeCodeVersion: null,
         };
 
         const result = sessionToWorktreeSession(dbSession);
@@ -117,6 +119,7 @@ describe('sessionToWorktreeSession', () => {
             createdAt: 'invalid-date',
             lastActivity: 'not-a-date',
             containerOutput: null,
+            claudeCodeVersion: null,
         };
 
         const result = sessionToWorktreeSession(dbSession);
@@ -168,6 +171,7 @@ describe('sessionToWorktreeSession', () => {
                 createdAt: '2025-11-24 10:30:45',
                 lastActivity: '2025-11-24 12:15:30',
                 containerOutput: null,
+                claudeCodeVersion: null,
             };
 
             const result = sessionToWorktreeSession(dbSession);

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -72,5 +72,6 @@ export const sessionToWorktreeSession = (dbSession: Session): WorktreeSession | 
         error: dbSession.error || undefined,
         containerOutput: dbSession.containerOutput || undefined,
         containerName: dbSession.containerName || undefined,
+        claudeCodeVersion: dbSession.claudeCodeVersion || undefined,
     };
 };

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -361,10 +361,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                     const statePath = getContainerStatePath(id);
                     rmSync(statePath, { recursive: true, force: true });
                 } catch (error) {
-                    console.warn(
-                        `Failed to remove state directory for session ${id}:`,
-                        error
-                    );
+                    console.warn(`Failed to remove state directory for session ${id}:`, error);
                 }
 
                 // Remove worktree


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_VERSION` constant (`2.1.96`) in `docker-manager.ts` alongside the existing `CLAUDE_CODE_IMAGE`
- Add `claudeCodeVersion` column to sessions table (with DB migration)
- Store the version when a Claude Code container starts
- Display version in session details under the Agent section in `viwo list`

Closes #94

## Test plan
- [x] Typecheck passes
- [x] All 48 tests pass
- [x] Lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)