### PR TITLE
fix: reset worktrees location to ~/.viwo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,8 @@ Git worktrees storage location is configurable through the `config-manager.ts`:
     - Relative paths are resolved relative to the app data directory
 - **Implementation**:
     - The `paths.ts` utility provides `expandTilde()` to expand `~` to the user's home directory
-    - `getWorktreesPath()` and `joinWorktreesPath()` check the configuration database first, then fall back to the default location
+    - `getWorktreesPath()` and `joinWorktreesPath()` check the configuration database first, then fall back to `~/.viwo/worktrees`
+    - Existing installations may continue using a legacy data directory for the database/config, but the worktrees reset/default location is still `~/.viwo/worktrees`
     - Tilde expansion happens automatically when setting the worktrees storage location
 - **Configuration methods**:
     - `setWorktreesStorageLocation(location)` - Set custom location (automatically expands tilde)
@@ -285,7 +286,7 @@ Commands in `packages/cli/src/commands/`:
 - `config worktrees` - Configure worktrees storage location
     - View current worktrees storage location (custom or default)
     - Set custom location (absolute or relative to app data directory)
-    - Reset to default location (app data directory)
+    - Reset to default location (`~/.viwo/worktrees`)
 - `config github` - Configure GitHub integration
     - Auto-detect token from `gh` CLI or `GITHUB_TOKEN` env var
     - Manual token entry

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -172,7 +172,7 @@ const runWorktreesLocationConfig = async (): Promise<void> => {
     console.log();
 
     const currentLocation = ConfigManager.getWorktreesStorageLocation();
-    const defaultLocation = AppPaths.joinDataPath('worktrees');
+    const defaultLocation = AppPaths.getDefaultWorktreesPath();
 
     console.log(chalk.bold('Current Worktrees Location'));
     if (currentLocation) {

--- a/packages/core/src/utils/__tests__/paths.test.ts
+++ b/packages/core/src/utils/__tests__/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { expandTilde, getLegacyDataPath, getDataPath } from '../paths';
+import { expandTilde, getLegacyDataPath, getDataPath, getDefaultWorktreesPath } from '../paths';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -66,5 +66,11 @@ describe('getDataPath', () => {
         const dataPath = getDataPath();
         expect(typeof dataPath).toBe('string');
         expect(dataPath.length).toBeGreaterThan(0);
+    });
+});
+
+describe('getDefaultWorktreesPath', () => {
+    it('should always point to ~/.viwo/worktrees', () => {
+        expect(getDefaultWorktreesPath()).toBe(join(homedir(), '.viwo', 'worktrees'));
     });
 });

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -14,6 +14,7 @@ import { homedir } from 'node:os';
 import { getWorktreesStorageLocation } from '../managers/config-manager.js';
 
 const DEFAULT_DATA_DIR = join(homedir(), '.viwo');
+const DEFAULT_WORKTREES_DIR = join(DEFAULT_DATA_DIR, 'worktrees');
 
 /**
  * Get the legacy platform-specific data directory path.
@@ -91,8 +92,15 @@ export const ensureDataPath = async (...segments: string[]): Promise<string> => 
 };
 
 /**
- * Get the worktrees directory path
- * Uses configured location if set, otherwise defaults to app data directory
+ * Get the default worktrees directory path.
+ * This always points to ~/.viwo/worktrees, even when an existing installation
+ * continues using a legacy data directory for its database/config.
+ */
+export const getDefaultWorktreesPath = (): string => DEFAULT_WORKTREES_DIR;
+
+/**
+ * Get the worktrees directory path.
+ * Uses configured location if set, otherwise defaults to ~/.viwo/worktrees.
  */
 export const getWorktreesPath = (): string => {
     const configuredLocation = getWorktreesStorageLocation();
@@ -102,12 +110,12 @@ export const getWorktreesPath = (): string => {
         if (isAbsolute(configuredLocation)) {
             return configuredLocation;
         }
-        // Otherwise, treat it as relative to app data directory
+        // Otherwise, treat it as relative to the active data directory
         return joinDataPath(configuredLocation);
     }
 
-    // Default to app data directory
-    return joinDataPath('worktrees');
+    // Reset/default always points to the new global default location
+    return getDefaultWorktreesPath();
 };
 
 /**
@@ -152,6 +160,7 @@ export const AppPaths = {
     getDataPath,
     joinDataPath,
     ensureDataPath,
+    getDefaultWorktreesPath,
     getWorktreesPath,
     joinWorktreesPath,
     ensureWorktreesPath,


### PR DESCRIPTION
## Summary
- decouple the default worktrees location from the active data/config directory
- make worktrees reset/default always resolve to `~/.viwo/worktrees`
- keep existing users on their current legacy data directory for sqlite/config
- update CLI messaging and docs to reflect the new behavior
- add a test for the default worktrees path

## Testing
- bun test packages/core/src/utils/__tests__/paths.test.ts

## Behavior
- existing installations can continue using the legacy data dir for the database/config
- `viwo config worktrees --reset` now points to `~/.viwo/worktrees`
- custom relative worktrees paths still resolve relative to the active data dir
