### PR TITLE
feat: add GitLab integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,11 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
 - `agent-manager.ts` - AI agent initialization with automatic container lifecycle management (only Claude Code implemented)
 - `repository-manager.ts` - Repository CRUD and default branch management
 - `port-manager.ts` - Port allocation via get-port
-- `config-manager.ts` - Configuration management (API keys, GitHub token, auth method, IDE preferences, model preference, worktrees storage location)
+- `config-manager.ts` - Configuration management (API keys, GitHub/GitLab tokens, GitLab instance URL, auth method, IDE preferences, model preference, worktrees storage location)
 - `credential-manager.ts` - OAuth credential extraction from host system (macOS Keychain, Linux credential files)
 - `ide-manager.ts` - IDE detection and launching
 - `github-manager.ts` - GitHub issue URL detection, fetching via REST API, prompt expansion; token resolution from gh CLI/env
+- `gitlab-manager.ts` - GitLab issue/MR URL detection, fetching via REST API, prompt expansion; token resolution from glab CLI/env; self-hosted instance support
 - `project-config-manager.ts` - Project configuration file detection and parsing (viwo.yml/viwo.yaml)
 
 **Schema-first validation** - All inputs validated with Zod schemas in `packages/core/src/schemas.ts`
@@ -111,6 +112,8 @@ VIWO (Virtualized Isolated Worktree Orchestrator) manages git worktrees, Docker 
     - Preferred IDE
     - Preferred Claude model (`'sonnet'`, `'opus'`, or `'haiku'` — defaults to Sonnet)
     - GitHub token (encrypted) for issue fetching and container forwarding
+    - GitLab token (encrypted) for issue/MR fetching and container forwarding
+    - GitLab instance URL for self-hosted GitLab support
     - Worktrees storage location (supports absolute or relative paths)
 - **Session storage**: The `sessions` table stores worktree session details including:
     - Container output (`containerOutput` field) - Full stdout/stderr captured when session completes or errors
@@ -195,28 +198,35 @@ VIWO supports two authentication methods, configured via `viwo auth`:
 
 The `credential-manager.ts` handles host credential extraction, and `config-manager.ts` stores the auth method preference.
 
-### GitHub Integration
+### GitHub & GitLab Integration
 
-When a `viwo start` prompt contains GitHub issue URLs (`https://github.com/{owner}/{repo}/issues/{number}`), VIWO automatically:
+When a `viwo start` prompt contains GitHub issue URLs (`https://github.com/{owner}/{repo}/issues/{number}`) or GitLab issue/MR URLs (`https://gitlab.com/{group}/{project}/-/issues/{number}`, `https://gitlab.com/{group}/{project}/-/merge_requests/{number}`), VIWO automatically:
 
-1. **Detects** issue URLs in the prompt via regex in `github-manager.ts`
-2. **Fetches** issue content (title, body, labels, comments) using the GitHub REST API
-3. **Expands** the prompt by replacing each URL with formatted issue content (markdown)
-4. **Forwards** the stored GitHub token as `GITHUB_TOKEN` env var to the container
+1. **Detects** supported URLs in the prompt
+2. **Fetches** issue/MR content (title, body/description, labels, comments) using the provider REST API
+3. **Expands** the prompt by replacing each URL with formatted markdown context
+4. **Forwards** stored provider tokens into the container for API access and git auth
 
-**Token management** (configured via `viwo config github`):
+**GitHub token management** (`viwo config github`):
 
 - Stored encrypted in the `configurations` table (`githubToken` field)
 - Auto-detection: tries `gh auth token` CLI first, then `GITHUB_TOKEN`/`GH_TOKEN` env vars
 - Manual entry also supported
-- Token is required when issue URLs are detected in a prompt; errors if missing
+
+**GitLab token management** (`viwo config gitlab`):
+
+- Stored encrypted in the `configurations` table (`gitlabToken` field)
+- Auto-detection: tries `glab auth token` CLI first, then `GITLAB_TOKEN` env var
+- Supports a configurable self-hosted instance URL via `gitlabInstanceUrl`
+- Manual entry also supported
 
 **Implementation**:
 
-- `github-manager.ts` handles URL parsing, API fetching, and prompt expansion
-- `config-manager.ts` handles encrypted token CRUD
-- `viwo.ts` calls `expandPromptWithIssues()` before starting the container
-- `agent-manager.ts` injects `GITHUB_TOKEN` into the container env via `buildClaudeEnv()`
+- `github-manager.ts` handles GitHub URL parsing, API fetching, and prompt expansion
+- `gitlab-manager.ts` handles GitLab issue/MR parsing, API fetching, self-hosted instance support, and prompt expansion
+- `config-manager.ts` handles encrypted token CRUD and GitLab instance URL storage
+- `viwo.ts` expands GitHub and GitLab URLs before starting the container
+- `agent-manager.ts` injects `GITHUB_TOKEN` and `GITLAB_TOKEN` into the container env via `buildClaudeEnv()`
 
 ### Container Lifecycle Management
 
@@ -236,7 +246,7 @@ Containers need working git for commits, pushes, and PR creation. VIWO achieves 
 
 1. **Mounting the repo's `.git/` directory** at `/repo-git` inside the container (only git internals, not the repo's working tree)
 2. **Rewriting the worktree's `.git` file** in `claude-bootstrap.sh` to point to `/repo-git/worktrees/<branch>` so git commands resolve correctly
-3. **Configuring `GITHUB_TOKEN` as a git credential helper** so pushes authenticate via the stored token
+3. **Configuring git credential helpers** so GitHub (`GITHUB_TOKEN`) and GitLab (`GITLAB_TOKEN`) pushes authenticate via the stored tokens
 
 The parent repo's working tree is never mounted — the container only sees the worktree at `/workspace` and the git metadata at `/repo-git`. The `getWorktreeGitInfo()` function in `git-manager.ts` parses the worktree's `.git` file to extract the gitdir path and derive mount paths.
 
@@ -290,6 +300,11 @@ Commands in `packages/cli/src/commands/`:
 - `config github` - Configure GitHub integration
     - Auto-detect token from `gh` CLI or `GITHUB_TOKEN` env var
     - Manual token entry
+    - View status and remove stored token
+- `config gitlab` - Configure GitLab integration
+    - Auto-detect token from `glab` CLI or `GITLAB_TOKEN` env var
+    - Manual token entry
+    - Configure/reset self-hosted GitLab instance URL
     - View status and remove stored token
 - `attach` - Attach to a running Claude Code session via tmux
     - With no args, shows interactive list of running sessions to choose from
@@ -378,6 +393,14 @@ viwo config github --auto
 viwo config github --set <token>
 viwo config github --remove
 viwo config github --status
+
+# Configure GitLab token / instance
+viwo config gitlab --auto
+viwo config gitlab --set <token>
+viwo config gitlab --instance https://gitlab.company.com
+viwo config gitlab --reset-instance
+viwo config gitlab --remove
+viwo config gitlab --status
 
 # List repos as JSON
 viwo repo list --json

--- a/packages/agents/claude-code/claude-bootstrap.sh
+++ b/packages/agents/claude-code/claude-bootstrap.sh
@@ -56,13 +56,18 @@ if [ -n "${VIWO_WORKTREE_NAME:-}" ] && [ -d "/repo-git" ]; then
     git config --global user.email "$GIT_AUTHOR_EMAIL"
   fi
 
-  # Use GITHUB_TOKEN for push auth and gh CLI if available
-  if [ -n "${GITHUB_TOKEN:-}" ]; then
-    git config --global credential.helper '!f() { echo "password=$GITHUB_TOKEN"; }; f'
-    git config --global credential.username 'x-access-token'
+  if [ -n "${GITHUB_TOKEN:-}" ] || [ -n "${GITLAB_TOKEN:-}" ]; then
+    git config --global credential.helper '!f() { host=""; while IFS= read -r line; do case "$line" in host=*) host="${line#host=}" ;; esac; done; if [ "$host" = "github.com" ] && [ -n "${GITHUB_TOKEN:-}" ]; then echo "username=x-access-token"; echo "password=$GITHUB_TOKEN"; elif [ "$host" = "${VIWO_GITLAB_HOST:-gitlab.com}" ] && [ -n "${GITLAB_TOKEN:-}" ]; then echo "username=oauth2"; echo "password=$GITLAB_TOKEN"; fi; }; f'
+  fi
 
-    # Auth gh CLI so `gh pr create` works
+  # Auth gh CLI so `gh pr create` works
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
     echo "$GITHUB_TOKEN" | gh auth login --with-token 2>/dev/null || true
+  fi
+
+  # Auth glab CLI if available so GitLab commands work inside the container
+  if [ -n "${GITLAB_TOKEN:-}" ]; then
+    glab auth login --hostname "${VIWO_GITLAB_HOST:-gitlab.com}" --token "$GITLAB_TOKEN" 2>/dev/null || true
   fi
 fi
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -72,9 +72,9 @@ const getCurrentModelSummary = (): string => {
 };
 
 const waitForEnter = async (message = 'Press Enter to continue...'): Promise<void> => {
-    console.log(chalk.gray(message));
-    await new Promise((resolve) => {
-        process.stdin.once('data', resolve);
+    await input({
+        message,
+        default: '',
     });
 };
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -655,13 +655,13 @@ const runGitLabConfig = async (): Promise<void> => {
                 ConfigManager.setGitLabToken(glabToken);
                 console.log(chalk.green('✓ GitLab token saved from glab CLI'));
                 console.log();
-                await waitForEnter();
+                await waitForEnter('Press Enter to go back to GitLab settings...');
                 return;
             }
 
             console.log(chalk.gray('No changes made'));
             console.log();
-            await waitForEnter();
+            await waitForEnter('Press Enter to go back to GitLab settings...');
             return;
         }
 
@@ -680,13 +680,13 @@ const runGitLabConfig = async (): Promise<void> => {
                 ConfigManager.setGitLabToken(envToken);
                 console.log(chalk.green('✓ GitLab token saved from environment'));
                 console.log();
-                await waitForEnter();
+                await waitForEnter('Press Enter to go back to GitLab settings...');
                 return;
             }
 
             console.log(chalk.gray('No changes made'));
             console.log();
-            await waitForEnter();
+            await waitForEnter('Press Enter to go back to GitLab settings...');
             return;
         }
 
@@ -694,7 +694,7 @@ const runGitLabConfig = async (): Promise<void> => {
         console.log(chalk.gray('Install the glab CLI (glab auth login) or set GITLAB_TOKEN env var.'));
         console.log(chalk.gray('You can also enter a token manually.'));
         console.log();
-        await waitForEnter();
+        await waitForEnter('Press Enter to go back to GitLab settings...');
         return;
     }
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -6,6 +6,7 @@ import {
     ConfigManager,
     CredentialManager,
     GitHubManager,
+    GitLabManager,
     type IDEType,
     type IDEInfo,
     type ModelType,
@@ -44,6 +45,25 @@ const MODEL_INFO: Record<ModelType, { name: string; hint: string }> = {
 const getCurrentGitHubSummary = (): string => {
     const hasToken = ConfigManager.hasGitHubToken();
     return hasToken ? chalk.green('configured') : chalk.gray('not set');
+};
+
+const getCurrentGitLabSummary = (): string => {
+    const hasToken = ConfigManager.hasGitLabToken();
+    const instanceUrl = ConfigManager.getGitLabInstanceUrl();
+
+    if (hasToken && instanceUrl) {
+        return chalk.green(`configured @ ${instanceUrl}`);
+    }
+
+    if (hasToken) {
+        return chalk.green('configured');
+    }
+
+    if (instanceUrl) {
+        return chalk.yellow(`instance set @ ${instanceUrl}`);
+    }
+
+    return chalk.gray('not set');
 };
 
 const getCurrentModelSummary = (): string => {
@@ -507,6 +527,182 @@ const runGitHubConfig = async (): Promise<void> => {
     }
 };
 
+// ─── GitLab configuration flow ───────────────────────────────────────────────
+
+const runGitLabConfig = async (): Promise<void> => {
+    console.clear();
+    console.log();
+    console.log(chalk.bold.cyan('GitLab Integration'));
+    console.log(chalk.gray('─'.repeat(50)));
+    console.log();
+
+    const hasToken = ConfigManager.hasGitLabToken();
+    const instanceUrl = ConfigManager.getGitLabInstanceUrl();
+
+    console.log(chalk.bold('GitLab Token'));
+    console.log(chalk.gray('  ') + (hasToken ? chalk.green('Configured') : 'Not set'));
+    console.log();
+
+    console.log(chalk.bold('GitLab Instance'));
+    console.log(chalk.gray('  ') + (instanceUrl ? chalk.green(instanceUrl) : 'https://gitlab.com'));
+    console.log();
+
+    const action = await select<string>({
+        message: 'What would you like to do?',
+        choices: [
+            {
+                name: chalk.cyan('Auto-detect token'),
+                value: 'auto',
+                description: 'Try glab CLI, then GITLAB_TOKEN env var',
+            },
+            {
+                name: chalk.cyan('Enter token manually'),
+                value: 'manual',
+                description: 'Paste a personal access token',
+            },
+            {
+                name: chalk.cyan('Set instance URL'),
+                value: 'instance',
+                description: 'Configure self-hosted GitLab URL',
+            },
+            ...(instanceUrl
+                ? [
+                      {
+                          name: chalk.yellow('Reset instance URL'),
+                          value: 'reset-instance',
+                          description: 'Use https://gitlab.com',
+                      },
+                  ]
+                : []),
+            ...(hasToken
+                ? [
+                      {
+                          name: chalk.yellow('Remove token'),
+                          value: 'remove',
+                          description: 'Delete stored GitLab token',
+                      },
+                  ]
+                : []),
+            {
+                name: chalk.gray('Cancel'),
+                value: 'cancel',
+                description: 'Go back without changes',
+            },
+        ],
+        pageSize: 10,
+    });
+
+    if (action === 'cancel') {
+        console.log(chalk.gray('No changes made'));
+        console.log();
+        return;
+    }
+
+    if (action === 'remove') {
+        ConfigManager.deleteGitLabToken();
+        console.log(chalk.green('✓ GitLab token removed'));
+        console.log();
+        return;
+    }
+
+    if (action === 'reset-instance') {
+        ConfigManager.deleteGitLabInstanceUrl();
+        console.log(chalk.green('✓ GitLab instance URL reset to https://gitlab.com'));
+        console.log();
+        return;
+    }
+
+    if (action === 'instance') {
+        const newInstanceUrl = await input({
+            message: 'Enter your GitLab instance URL',
+            default: instanceUrl ?? 'https://gitlab.com',
+            validate: (value) => {
+                if (!value || !value.trim()) {
+                    return 'Instance URL cannot be empty';
+                }
+                return true;
+            },
+        });
+
+        ConfigManager.setGitLabInstanceUrl(newInstanceUrl.trim());
+        console.log(chalk.green('✓ GitLab instance URL saved'));
+        console.log();
+        return;
+    }
+
+    if (action === 'auto') {
+        console.log();
+        console.log(chalk.gray('Checking glab CLI...'));
+
+        const glabToken = await GitLabManager.resolveGitLabTokenFromGlabCli();
+        if (glabToken) {
+            const confirm = await select<boolean>({
+                message: 'Found token from glab CLI. Use it?',
+                choices: [
+                    { name: 'Yes, save it', value: true },
+                    { name: 'No, cancel', value: false },
+                ],
+            });
+
+            if (confirm) {
+                ConfigManager.setGitLabToken(glabToken);
+                console.log(chalk.green('✓ GitLab token saved from glab CLI'));
+                console.log();
+                return;
+            }
+
+            console.log(chalk.gray('No changes made'));
+            console.log();
+            return;
+        }
+
+        console.log(chalk.gray('Checking GITLAB_TOKEN env var...'));
+        const envToken = GitLabManager.resolveGitLabTokenFromEnv();
+        if (envToken) {
+            const confirm = await select<boolean>({
+                message: 'Found GITLAB_TOKEN in environment. Use it?',
+                choices: [
+                    { name: 'Yes, save it', value: true },
+                    { name: 'No, cancel', value: false },
+                ],
+            });
+
+            if (confirm) {
+                ConfigManager.setGitLabToken(envToken);
+                console.log(chalk.green('✓ GitLab token saved from environment'));
+                console.log();
+                return;
+            }
+
+            console.log(chalk.gray('No changes made'));
+            console.log();
+            return;
+        }
+
+        console.log(chalk.yellow('No GitLab token found automatically.'));
+        console.log(chalk.gray('Install the glab CLI (glab auth login) or set GITLAB_TOKEN env var.'));
+        console.log(chalk.gray('You can also enter a token manually.'));
+        console.log();
+        return;
+    }
+
+    if (action === 'manual') {
+        const token = await password({
+            message: 'Enter your GitLab personal access token',
+            validate: (value) => {
+                if (!value || !value.trim()) {
+                    return 'Token cannot be empty';
+                }
+                return true;
+            },
+        });
+
+        ConfigManager.setGitLabToken(token.trim());
+        console.log(chalk.green('✓ GitLab token saved'));
+        console.log();
+    }
+};
+
 // ─── Authentication configuration flow ──────────────────────────────────────
 
 const runAuthConfig = async (): Promise<void> => {
@@ -655,6 +851,10 @@ const runConfigMenu = async (): Promise<void> => {
                     value: 'github',
                 },
                 {
+                    name: `GitLab integration      ${chalk.gray(`(${getCurrentGitLabSummary()})`)}`,
+                    value: 'gitlab',
+                },
+                {
                     name: `Authentication          ${chalk.gray(`(${getCurrentAuthSummary()})`)}`,
                     value: 'auth',
                 },
@@ -677,6 +877,9 @@ const runConfigMenu = async (): Promise<void> => {
                 break;
             case 'github':
                 await runGitHubConfig();
+                break;
+            case 'gitlab':
+                await runGitLabConfig();
                 break;
             case 'auth':
                 await runAuthConfig();
@@ -863,6 +1066,81 @@ const githubCommand = new Command('github')
         }
     });
 
+const gitlabCommand = new Command('gitlab')
+    .description('Configure GitLab integration')
+    .option('--auto', 'Auto-detect token from glab CLI or GITLAB_TOKEN env var')
+    .option('--set <token>', 'Set GitLab token directly')
+    .option('--remove', 'Remove stored GitLab token')
+    .option('--status', 'Show current GitLab token status')
+    .option('--instance <url>', 'Set GitLab instance URL (for self-hosted GitLab)')
+    .option('--reset-instance', 'Reset GitLab instance URL to https://gitlab.com')
+    .action(async (options) => {
+        try {
+            await preflightChecksOrExit({ requireGit: false, requireDocker: false });
+
+            if (options.status) {
+                const hasToken = ConfigManager.hasGitLabToken();
+                const instanceUrl = ConfigManager.getGitLabInstanceUrl() ?? 'https://gitlab.com';
+                console.log(hasToken ? `configured (${instanceUrl})` : `not set (${instanceUrl})`);
+                return;
+            }
+
+            if (options.resetInstance) {
+                ConfigManager.deleteGitLabInstanceUrl();
+                console.log(chalk.green('GitLab instance URL reset to https://gitlab.com.'));
+                return;
+            }
+
+            if (options.instance) {
+                ConfigManager.setGitLabInstanceUrl(options.instance);
+                console.log(chalk.green('GitLab instance URL saved.'));
+                return;
+            }
+
+            if (options.remove) {
+                ConfigManager.deleteGitLabToken();
+                console.log(chalk.green('GitLab token removed.'));
+                return;
+            }
+
+            if (options.set) {
+                ConfigManager.setGitLabToken(options.set);
+                console.log(chalk.green('GitLab token saved.'));
+                return;
+            }
+
+            if (options.auto) {
+                let token = await GitLabManager.resolveGitLabTokenFromGlabCli();
+                if (!token) token = GitLabManager.resolveGitLabTokenFromEnv();
+
+                if (token) {
+                    ConfigManager.setGitLabToken(token);
+                    console.log(chalk.green('GitLab token auto-detected and saved.'));
+                } else {
+                    console.error(
+                        chalk.red(
+                            'No GitLab token found. Install glab CLI or set GITLAB_TOKEN env var.'
+                        )
+                    );
+                    process.exit(1);
+                }
+                return;
+            }
+
+            await runGitLabConfig();
+        } catch (error) {
+            if ((error as any).name === 'ExitPromptError') {
+                console.log(chalk.gray('Operation cancelled'));
+                process.exit(0);
+            }
+            console.error(
+                chalk.red('Configuration failed:'),
+                error instanceof Error ? error.message : String(error)
+            );
+            process.exit(1);
+        }
+    });
+
 const authConfigCommand = new Command('auth')
     .description('Configure authentication method (API key or OAuth)')
     .option('--set <key>', 'Set Anthropic API key directly')
@@ -936,6 +1214,7 @@ export const configCommand = new Command('config')
     .addCommand(worktreesCommand)
     .addCommand(modelCommand)
     .addCommand(githubCommand)
+    .addCommand(gitlabCommand)
     .addCommand(authConfigCommand)
     .action(async () => {
         try {

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -71,6 +71,13 @@ const getCurrentModelSummary = (): string => {
     return pref ? MODEL_INFO[pref].name : chalk.gray('default (Sonnet)');
 };
 
+const waitForEnter = async (message = 'Press Enter to continue...'): Promise<void> => {
+    console.log(chalk.gray(message));
+    await new Promise((resolve) => {
+        process.stdin.once('data', resolve);
+    });
+};
+
 // ─── IDE configuration flow ─────────────────────────────────────────────────
 
 const runIDEConfig = async (): Promise<void> => {
@@ -648,11 +655,13 @@ const runGitLabConfig = async (): Promise<void> => {
                 ConfigManager.setGitLabToken(glabToken);
                 console.log(chalk.green('✓ GitLab token saved from glab CLI'));
                 console.log();
+                await waitForEnter();
                 return;
             }
 
             console.log(chalk.gray('No changes made'));
             console.log();
+            await waitForEnter();
             return;
         }
 
@@ -671,11 +680,13 @@ const runGitLabConfig = async (): Promise<void> => {
                 ConfigManager.setGitLabToken(envToken);
                 console.log(chalk.green('✓ GitLab token saved from environment'));
                 console.log();
+                await waitForEnter();
                 return;
             }
 
             console.log(chalk.gray('No changes made'));
             console.log();
+            await waitForEnter();
             return;
         }
 
@@ -683,6 +694,7 @@ const runGitLabConfig = async (): Promise<void> => {
         console.log(chalk.gray('Install the glab CLI (glab auth login) or set GITLAB_TOKEN env var.'));
         console.log(chalk.gray('You can also enter a token manually.'));
         console.log();
+        await waitForEnter();
         return;
     }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import * as clack from '@clack/prompts';
 import { readFileSync } from 'fs';
-import { viwo, ConfigManager, GitHubManager, GitManager } from '@viwo/core';
+import { viwo, ConfigManager, GitHubManager, GitLabManager, GitManager } from '@viwo/core';
 import { getStatusBadge } from '../utils/formatters';
 import { preflightChecksOrExit } from '../utils/prerequisites';
 import { multilineInput } from '../utils/multiline-input';
@@ -177,6 +177,55 @@ export const startCommand = new Command('start')
                     if (tokenInput && tokenInput.trim()) {
                         ConfigManager.setGitHubToken(tokenInput.trim());
                         clack.log.success('GitHub token saved.');
+                    }
+                }
+            }
+
+            const gitlabUrls = GitLabManager.parseGitLabResourceUrls(prompt);
+            if (gitlabUrls.length > 0 && !ConfigManager.hasGitLabToken()) {
+                clack.log.info(
+                    `Detected ${gitlabUrls.length} GitLab issue/MR URL(s). A GitLab token is needed to fetch context.`
+                );
+
+                const setupChoice = await clack.select({
+                    message: 'Set up GitLab token now?',
+                    options: [
+                        { label: 'Auto-detect (glab CLI / env var)', value: 'auto' },
+                        { label: 'Enter token manually', value: 'manual' },
+                        { label: 'Skip — continue without GitLab context', value: 'skip' },
+                    ],
+                });
+
+                if (clack.isCancel(setupChoice)) {
+                    clack.cancel('Operation cancelled.');
+                    process.exit(0);
+                }
+
+                if (setupChoice === 'auto') {
+                    let resolved = await GitLabManager.resolveGitLabTokenFromGlabCli();
+                    if (!resolved) resolved = GitLabManager.resolveGitLabTokenFromEnv();
+
+                    if (resolved) {
+                        ConfigManager.setGitLabToken(resolved);
+                        clack.log.success('GitLab token saved.');
+                    } else {
+                        clack.log.warn(
+                            'No token found. Install glab CLI (glab auth login) or set GITLAB_TOKEN env var.'
+                        );
+                    }
+                } else if (setupChoice === 'manual') {
+                    const tokenInput = await clack.password({
+                        message: 'Enter your GitLab personal access token:',
+                    });
+
+                    if (clack.isCancel(tokenInput)) {
+                        clack.cancel('Operation cancelled.');
+                        process.exit(0);
+                    }
+
+                    if (tokenInput && tokenInput.trim()) {
+                        ConfigManager.setGitLabToken(tokenInput.trim());
+                        clack.log.success('GitLab token saved.');
                     }
                 }
             }

--- a/packages/core/drizzle/0011_large_silver_centurion.sql
+++ b/packages/core/drizzle/0011_large_silver_centurion.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `configurations` ADD `gitlab_token` text;--> statement-breakpoint
+ALTER TABLE `configurations` ADD `gitlab_instance_url` text;

--- a/packages/core/drizzle/meta/0011_snapshot.json
+++ b/packages/core/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,327 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "de604d05-8979-41ee-8953-af98ae92c0e3",
+  "prevId": "8ef4bee0-d552-4ef4-9795-59e1ebca2a8b",
+  "tables": {
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repoId": {
+          "name": "repoId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gitWorktreeName": {
+          "name": "gitWorktreeName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerName": {
+          "name": "containerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerId": {
+          "name": "containerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerImage": {
+          "name": "containerImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'initializing'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "containerOutput": {
+          "name": "containerOutput",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claudeCodeVersion": {
+          "name": "claudeCodeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "lastActivity": {
+          "name": "lastActivity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "configurations": {
+      "name": "configurations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_ide": {
+          "name": "preferred_ide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktrees_storage_location": {
+          "name": "worktrees_storage_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_model": {
+          "name": "preferred_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_token": {
+          "name": "github_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gitlab_token": {
+          "name": "gitlab_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gitlab_instance_url": {
+          "name": "gitlab_instance_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1775684060731,
       "tag": "0010_wonderful_roughhouse",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1775778047511,
+      "tag": "0011_large_silver_centurion",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db-schemas/configuration.ts
+++ b/packages/core/src/db-schemas/configuration.ts
@@ -8,6 +8,8 @@ export const configurations = sqliteTable('configurations', {
     worktreesStorageLocation: text('worktrees_storage_location'),
     preferredModel: text('preferred_model'),
     githubToken: text('github_token'),
+    gitlabToken: text('gitlab_token'),
+    gitlabInstanceUrl: text('gitlab_instance_url'),
     createdAt: text('created_at'),
     updatedAt: text('updated_at'),
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export * as ConfigManager from './managers/config-manager';
 export * as CredentialManager from './managers/credential-manager';
 export * as IDEManager from './managers/ide-manager';
 export * as GitHubManager from './managers/github-manager';
+export * as GitLabManager from './managers/gitlab-manager';
 export * as ProjectConfigManager from './managers/project-config-manager';
 
 // Export repository management

--- a/packages/core/src/managers/__tests__/gitlab-manager.test.ts
+++ b/packages/core/src/managers/__tests__/gitlab-manager.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+    getGitLabApiBaseUrl,
+    getGitLabInstanceBaseUrl,
+    parseGitLabResourceUrls,
+    resolveGitLabTokenFromEnv,
+} from '../gitlab-manager';
+import {
+    deleteGitLabInstanceUrl,
+    setGitLabInstanceUrl,
+} from '../config-manager';
+
+describe('gitlab-manager', () => {
+    afterEach(() => {
+        deleteGitLabInstanceUrl();
+        delete process.env.GITLAB_TOKEN;
+    });
+
+    test('parses GitLab issue and merge request URLs on gitlab.com', () => {
+        const urls = parseGitLabResourceUrls(
+            [
+                'Fix this issue: https://gitlab.com/group/project/-/issues/123',
+                'See MR: https://gitlab.com/group/subgroup/project/-/merge_requests/456',
+            ].join('\n')
+        );
+
+        expect(urls).toEqual([
+            {
+                instanceUrl: 'https://gitlab.com',
+                projectPath: 'group/project',
+                kind: 'issue',
+                number: 123,
+                fullUrl: 'https://gitlab.com/group/project/-/issues/123',
+            },
+            {
+                instanceUrl: 'https://gitlab.com',
+                projectPath: 'group/subgroup/project',
+                kind: 'merge_request',
+                number: 456,
+                fullUrl: 'https://gitlab.com/group/subgroup/project/-/merge_requests/456',
+            },
+        ]);
+    });
+
+    test('parses configured self-hosted GitLab URLs', () => {
+        setGitLabInstanceUrl('https://gitlab.company.com');
+
+        const urls = parseGitLabResourceUrls(
+            'https://gitlab.company.com/platform/api/-/issues/42'
+        );
+
+        expect(urls).toEqual([
+            {
+                instanceUrl: 'https://gitlab.company.com',
+                projectPath: 'platform/api',
+                kind: 'issue',
+                number: 42,
+                fullUrl: 'https://gitlab.company.com/platform/api/-/issues/42',
+            },
+        ]);
+    });
+
+    test('deduplicates repeated URLs', () => {
+        const text =
+            'https://gitlab.com/group/project/-/issues/123 and again https://gitlab.com/group/project/-/issues/123';
+
+        const urls = parseGitLabResourceUrls(text);
+
+        expect(urls).toHaveLength(1);
+    });
+
+    test('uses configured instance URL for API base URL', () => {
+        setGitLabInstanceUrl('gitlab.company.com');
+
+        expect(getGitLabInstanceBaseUrl()).toBe('https://gitlab.company.com');
+        expect(getGitLabApiBaseUrl()).toBe('https://gitlab.company.com/api/v4');
+    });
+
+    test('resolves token from environment', () => {
+        process.env.GITLAB_TOKEN = 'glpat-test-token';
+
+        expect(resolveGitLabTokenFromEnv()).toBe('glpat-test-token');
+    });
+});

--- a/packages/core/src/managers/agent-manager.ts
+++ b/packages/core/src/managers/agent-manager.ts
@@ -13,7 +13,7 @@ import {
     pullImage,
     generateContainerName,
 } from './docker-manager';
-import { getApiKey, getAuthMethod, getGitHubToken } from './config-manager';
+import { getApiKey, getAuthMethod, getGitHubToken, getGitLabInstanceUrl, getGitLabToken } from './config-manager';
 import { extractOAuthCredentials, extractOAuthAccountInfo, isOAuthTokenExpired } from './credential-manager';
 import { getWorktreeGitInfo } from './git-manager';
 import { ensureContainerStatePath } from '../utils/paths';
@@ -68,6 +68,11 @@ const getGitUserConfig = (): { name: string; email: string } | null => {
     return null;
 };
 
+const getGitLabHost = (instanceUrl: string): string => {
+    const withProtocol = /^https?:\/\//i.test(instanceUrl) ? instanceUrl : `https://${instanceUrl}`;
+    return new URL(withProtocol).host;
+};
+
 const buildClaudeEnv = (config: AgentConfig): Record<string, string> => {
     const env: Record<string, string> = {
         VIWO_PROMPT: config.initialPrompt,
@@ -82,6 +87,15 @@ const buildClaudeEnv = (config: AgentConfig): Record<string, string> => {
     if (githubToken) {
         env.GITHUB_TOKEN = githubToken;
     }
+
+    const gitlabToken = getGitLabToken();
+    if (gitlabToken) {
+        env.GITLAB_TOKEN = gitlabToken;
+    }
+
+    const gitlabInstanceUrl = getGitLabInstanceUrl() ?? 'https://gitlab.com';
+    env.VIWO_GITLAB_INSTANCE_URL = gitlabInstanceUrl;
+    env.VIWO_GITLAB_HOST = getGitLabHost(gitlabInstanceUrl);
 
     const gitUser = getGitUserConfig();
     if (gitUser) {

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -290,6 +290,98 @@ export const deleteGitHubToken = (): void => {
         .run();
 };
 
+// ─── GitLab Configuration ───────────────────────────────────────────────────
+
+const normalizeGitLabInstanceUrl = (instanceUrl: string): string => {
+    const trimmed = instanceUrl.trim();
+    const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    return withProtocol.replace(/\/+$/, '');
+};
+
+export const setGitLabToken = (token: string): void => {
+    const encryptedToken = encrypt(token);
+    const now = new Date().toISOString();
+    const existing = db.select().from(configurations).limit(1).all();
+
+    if (existing.length > 0) {
+        db.update(configurations)
+            .set({ gitlabToken: encryptedToken, updatedAt: now })
+            .where(eq(configurations.id, existing[0]!.id))
+            .run();
+    } else {
+        db.insert(configurations)
+            .values({ gitlabToken: encryptedToken, createdAt: now, updatedAt: now })
+            .run();
+    }
+};
+
+export const getGitLabToken = (): string | null => {
+    const config = db.select().from(configurations).limit(1).all();
+
+    if (config.length === 0) return null;
+
+    const encryptedToken = config[0]!.gitlabToken;
+    if (!encryptedToken) return null;
+
+    try {
+        return decrypt(encryptedToken);
+    } catch (e) {
+        console.log('Error decrypting GitLab token:', e);
+        return null;
+    }
+};
+
+export const hasGitLabToken = (): boolean => {
+    return getGitLabToken() !== null;
+};
+
+export const deleteGitLabToken = (): void => {
+    const config = db.select().from(configurations).limit(1).get();
+    if (!config) return;
+
+    db.update(configurations)
+        .set({ gitlabToken: null, updatedAt: new Date().toISOString() })
+        .where(eq(configurations.id, config.id))
+        .run();
+};
+
+export const setGitLabInstanceUrl = (instanceUrl: string): void => {
+    const normalizedUrl = normalizeGitLabInstanceUrl(instanceUrl);
+    const now = new Date().toISOString();
+    const existing = db.select().from(configurations).limit(1).all();
+
+    if (existing.length > 0) {
+        db.update(configurations)
+            .set({ gitlabInstanceUrl: normalizedUrl, updatedAt: now })
+            .where(eq(configurations.id, existing[0]!.id))
+            .run();
+    } else {
+        db.insert(configurations)
+            .values({ gitlabInstanceUrl: normalizedUrl, createdAt: now, updatedAt: now })
+            .run();
+    }
+};
+
+export const getGitLabInstanceUrl = (): string | null => {
+    const config = db.select().from(configurations).limit(1).all();
+
+    if (config.length === 0) {
+        return null;
+    }
+
+    return config[0]!.gitlabInstanceUrl || null;
+};
+
+export const deleteGitLabInstanceUrl = (): void => {
+    const config = db.select().from(configurations).limit(1).get();
+    if (!config) return;
+
+    db.update(configurations)
+        .set({ gitlabInstanceUrl: null, updatedAt: new Date().toISOString() })
+        .where(eq(configurations.id, config.id))
+        .run();
+};
+
 export const deleteWorktreesStorageLocation = (): void => {
     const config = db.select().from(configurations).limit(1).get();
 
@@ -420,4 +512,11 @@ export const config = {
     getGitHubToken,
     hasGitHubToken,
     deleteGitHubToken,
+    setGitLabToken,
+    getGitLabToken,
+    hasGitLabToken,
+    deleteGitLabToken,
+    setGitLabInstanceUrl,
+    getGitLabInstanceUrl,
+    deleteGitLabInstanceUrl,
 };

--- a/packages/core/src/managers/gitlab-manager.ts
+++ b/packages/core/src/managers/gitlab-manager.ts
@@ -1,0 +1,246 @@
+import { getGitLabInstanceUrl, getGitLabToken } from './config-manager';
+
+const DEFAULT_GITLAB_INSTANCE_URL = 'https://gitlab.com';
+const MAX_COMMENTS = 25;
+
+export interface GitLabComment {
+    author: string;
+    body: string;
+    createdAt: string;
+}
+
+export interface GitLabResource {
+    instanceUrl: string;
+    projectPath: string;
+    kind: 'issue' | 'merge_request';
+    number: number;
+    title: string;
+    body: string | null;
+    state: string;
+    labels: string[];
+    comments: GitLabComment[];
+}
+
+export interface ParsedGitLabResourceUrl {
+    instanceUrl: string;
+    projectPath: string;
+    kind: 'issue' | 'merge_request';
+    number: number;
+    fullUrl: string;
+}
+
+const normalizeInstanceUrl = (instanceUrl: string | null | undefined): string => {
+    if (!instanceUrl) return DEFAULT_GITLAB_INSTANCE_URL;
+
+    const trimmed = instanceUrl.trim();
+    const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    return withProtocol.replace(/\/+$/, '');
+};
+
+const escapeRegex = (value: string): string => {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};
+
+const getSupportedHosts = (): string[] => {
+    const configuredInstanceUrl = getGitLabInstanceUrl();
+    const configuredHost = new URL(normalizeInstanceUrl(configuredInstanceUrl)).host;
+    return Array.from(new Set(['gitlab.com', configuredHost]));
+};
+
+export const getGitLabApiBaseUrl = (): string => {
+    return `${normalizeInstanceUrl(getGitLabInstanceUrl())}/api/v4`;
+};
+
+export const getGitLabInstanceBaseUrl = (): string => {
+    return normalizeInstanceUrl(getGitLabInstanceUrl());
+};
+
+export const parseGitLabResourceUrls = (text: string): ParsedGitLabResourceUrl[] => {
+    const hosts = getSupportedHosts();
+    const hostPattern = hosts.map(escapeRegex).join('|');
+    const regex = new RegExp(
+        `https?:\\/\\/(${hostPattern})\\/((?:[^/]+\\/)+[^/]+)\\/-\\/(issues|merge_requests)\\/(\\d+)`,
+        'g'
+    );
+
+    const matches: ParsedGitLabResourceUrl[] = [];
+    const seen = new Set<string>();
+
+    for (const match of text.matchAll(regex)) {
+        const host = match[1]!;
+        const projectPath = match[2]!;
+        const resourceType = match[3]!;
+        const number = parseInt(match[4]!, 10);
+        const kind = resourceType === 'merge_requests' ? 'merge_request' : 'issue';
+        const key = `${host}/${projectPath}/${kind}#${number}`;
+
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        matches.push({
+            instanceUrl: `https://${host}`,
+            projectPath,
+            kind,
+            number,
+            fullUrl: match[0],
+        });
+    }
+
+    return matches;
+};
+
+const fetchJson = async (url: string, token: string): Promise<any> => {
+    const response = await fetch(url, {
+        headers: {
+            'PRIVATE-TOKEN': token,
+            Accept: 'application/json',
+        },
+    });
+
+    if (response.status === 401) {
+        throw new Error(
+            'GitLab token is invalid or expired. Run "viwo config gitlab" to update it.'
+        );
+    }
+
+    if (!response.ok) {
+        throw new Error(`GitLab API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+};
+
+export const fetchGitLabResource = async (options: {
+    instanceUrl: string;
+    projectPath: string;
+    kind: 'issue' | 'merge_request';
+    number: number;
+    token: string;
+}): Promise<GitLabResource> => {
+    const { instanceUrl, projectPath, kind, number, token } = options;
+    const normalizedInstanceUrl = normalizeInstanceUrl(instanceUrl);
+    const apiBaseUrl = `${normalizedInstanceUrl}/api/v4/projects/${encodeURIComponent(projectPath)}`;
+    const resourcePath = kind === 'issue' ? 'issues' : 'merge_requests';
+    const notesPath = kind === 'issue' ? 'notes' : 'notes';
+    const baseUrl = `${apiBaseUrl}/${resourcePath}/${number}`;
+
+    const [resourceData, commentsData] = await Promise.all([
+        fetchJson(baseUrl, token),
+        fetchJson(`${baseUrl}/${notesPath}?per_page=${MAX_COMMENTS}`, token),
+    ]);
+
+    return {
+        instanceUrl: normalizedInstanceUrl,
+        projectPath,
+        kind,
+        number,
+        title: resourceData.title,
+        body: resourceData.description ?? null,
+        state: resourceData.state,
+        labels: resourceData.labels ?? [],
+        comments: (commentsData ?? []).map((comment: any) => ({
+            author: comment.author?.username ?? comment.author?.name ?? 'unknown',
+            body: comment.body ?? '',
+            createdAt: comment.created_at,
+        })),
+    };
+};
+
+const formatGitLabResource = (resource: GitLabResource): string => {
+    const parts: string[] = [];
+    const resourceName = resource.kind === 'issue' ? 'Issue' : 'Merge Request';
+
+    parts.push(`## GitLab ${resourceName} #${resource.number}: ${resource.title}`);
+    parts.push(`**Project:** ${resource.projectPath}`);
+    parts.push(`**Instance:** ${resource.instanceUrl}`);
+    parts.push(`**State:** ${resource.state}`);
+
+    if (resource.labels.length > 0) {
+        parts.push(`**Labels:** ${resource.labels.join(', ')}`);
+    }
+
+    if (resource.body) {
+        parts.push('');
+        parts.push(resource.body);
+    }
+
+    if (resource.comments.length > 0) {
+        parts.push('');
+        parts.push('### Comments');
+
+        for (const comment of resource.comments) {
+            parts.push('');
+            parts.push(`**@${comment.author}** (${comment.createdAt}):`);
+            parts.push(comment.body);
+        }
+    }
+
+    return parts.join('\n');
+};
+
+export const expandPromptWithGitLabResources = async (prompt: string): Promise<string> => {
+    const resourceUrls = parseGitLabResourceUrls(prompt);
+    if (resourceUrls.length === 0) return prompt;
+
+    const token = getGitLabToken();
+    if (!token) return prompt;
+
+    const resources = await Promise.all(
+        resourceUrls.map((resourceUrl) =>
+            fetchGitLabResource({
+                instanceUrl: resourceUrl.instanceUrl,
+                projectPath: resourceUrl.projectPath,
+                kind: resourceUrl.kind,
+                number: resourceUrl.number,
+                token,
+            })
+        )
+    );
+
+    let expandedPrompt = prompt;
+    for (let i = 0; i < resourceUrls.length; i++) {
+        expandedPrompt = expandedPrompt.replace(
+            resourceUrls[i]!.fullUrl,
+            formatGitLabResource(resources[i]!)
+        );
+    }
+
+    return expandedPrompt;
+};
+
+export const resolveGitLabTokenFromGlabCli = async (): Promise<string | null> => {
+    const configuredHost = new URL(getGitLabInstanceBaseUrl()).host;
+    const commands = configuredHost === 'gitlab.com'
+        ? [['glab', 'auth', 'token'], ['glab', 'auth', 'token', '--hostname', configuredHost]]
+        : [['glab', 'auth', 'token', '--hostname', configuredHost], ['glab', 'auth', 'token']];
+
+    for (const command of commands) {
+        try {
+            const proc = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' });
+            const output = await new Response(proc.stdout).text();
+            const exitCode = await proc.exited;
+
+            if (exitCode === 0 && output.trim()) {
+                return output.trim();
+            }
+        } catch {
+            // glab not installed or not authed
+        }
+    }
+
+    return null;
+};
+
+export const resolveGitLabTokenFromEnv = (): string | null => {
+    return process.env.GITLAB_TOKEN ?? null;
+};
+
+export const gitlab = {
+    getGitLabApiBaseUrl,
+    getGitLabInstanceBaseUrl,
+    parseGitLabResourceUrls,
+    fetchGitLabResource,
+    expandPromptWithGitLabResources,
+    resolveGitLabTokenFromGlabCli,
+    resolveGitLabTokenFromEnv,
+};

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -45,7 +45,7 @@ export const migrations: Migration[] = [
             	\`createdAt\` text,
             	\`lastActivity\` text
             );
-        `,
+        `
     },
     {
         version: 2,
@@ -53,7 +53,7 @@ export const migrations: Migration[] = [
         up: `
             ALTER TABLE \`sessions\` RENAME COLUMN "agentId" TO "agent";
             ALTER TABLE \`sessions\` ADD \`branchName\` text NOT NULL;
-        `,
+        `
     },
     {
         version: 3,
@@ -81,7 +81,7 @@ export const migrations: Migration[] = [
             DROP TABLE \`sessions\`;
             ALTER TABLE \`__new_sessions\` RENAME TO \`sessions\`;
             PRAGMA foreign_keys=ON;
-        `,
+        `
     },
     {
         version: 4,
@@ -99,35 +99,35 @@ export const migrations: Migration[] = [
             DROP TABLE \`configurations\`;
             ALTER TABLE \`__new_configurations\` RENAME TO \`configurations\`;
             PRAGMA foreign_keys=ON;
-        `,
+        `
     },
     {
         version: 5,
         name: 'puzzling_anita_blake',
         up: `
             ALTER TABLE \`configurations\` ADD \`preferred_ide\` text;
-        `,
+        `
     },
     {
         version: 6,
         name: 'confused_the_renegades',
         up: `
             ALTER TABLE \`configurations\` ADD \`worktrees_storage_location\` text;
-        `,
+        `
     },
     {
         version: 7,
         name: 'swift_silverclaw',
         up: `
             ALTER TABLE \`sessions\` ADD \`containerOutput\` text;
-        `,
+        `
     },
     {
         version: 8,
         name: 'last_mentor',
         up: `
             ALTER TABLE \`configurations\` ADD \`auth_method\` text;
-        `,
+        `
     },
     {
         version: 9,
@@ -135,20 +135,28 @@ export const migrations: Migration[] = [
         up: `
             ALTER TABLE \`repositories\` ADD \`default_branch\` text;
             ALTER TABLE \`configurations\` ADD \`preferred_model\` text;
-        `,
+        `
     },
     {
         version: 10,
         name: 'careful_rumiko_fujikawa',
         up: `
             ALTER TABLE \`sessions\` ADD \`claudeCodeVersion\` text;
-        `,
+        `
     },
     {
         version: 11,
         name: 'wonderful_roughhouse',
         up: `
             ALTER TABLE \`configurations\` ADD \`github_token\` text;
-        `,
+        `
     },
+    {
+        version: 12,
+        name: 'large_silver_centurion',
+        up: `
+            ALTER TABLE \`configurations\` ADD \`gitlab_token\` text;
+            ALTER TABLE \`configurations\` ADD \`gitlab_instance_url\` text;
+        `
+    }
 ];

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -40,6 +40,7 @@ import { sessionToWorktreeSession } from './utils/types';
 import { loadProjectConfig } from './managers/project-config-manager';
 import { getPreferredModel } from './managers/config-manager';
 import { expandPromptWithIssues } from './managers/github-manager';
+import { expandPromptWithGitLabResources } from './managers/gitlab-manager';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -227,8 +228,11 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
             };
 
             try {
-                // Expand GitHub issue URLs in prompt
-                const expandedPrompt = await expandPromptWithIssues(validatedOptions.prompt);
+                // Expand issue/MR URLs in prompt
+                const promptWithGitHubIssues = await expandPromptWithIssues(validatedOptions.prompt);
+                const expandedPrompt = await expandPromptWithGitLabResources(
+                    promptWithGitHubIssues
+                );
 
                 // Phase 2: Start container
                 const containerResult = await startContainerPhase({


### PR DESCRIPTION
## Summary
- add GitLab integration alongside the existing GitHub integration
- support GitLab issue/MR URL expansion, token management, self-hosted instance configuration, and container credential injection
- improve the interactive GitLab config auto-detect UX so result screens are readable and clearly return to GitLab settings

## Changes
### Core
- add `packages/core/src/managers/gitlab-manager.ts`
  - detect GitLab issue URLs: `/-/issues/:number`
  - detect GitLab merge request URLs: `/-/merge_requests/:number`
  - fetch issue/MR details and comments from GitLab REST API
  - support self-hosted GitLab via configured instance URL
  - resolve tokens from `glab auth token` or `GITLAB_TOKEN`
- expand prompts with both GitHub and GitLab context in `packages/core/src/viwo.ts`
- inject `GITLAB_TOKEN` plus GitLab host metadata into Claude containers in `agent-manager.ts`
- update `packages/agents/claude-code/claude-bootstrap.sh`
  - configure git credential helper for both GitHub and GitLab
  - attempt `glab` auth inside the container when a GitLab token is present

### Config / DB
- add configuration fields:
  - `gitlab_token`
  - `gitlab_instance_url`
- add config manager methods:
  - `get/set/deleteGitLabToken`
  - `get/set/deleteGitLabInstanceUrl`
- generate Drizzle migration and regenerate JS migrations

### CLI
- add `viwo config gitlab`
  - `--auto`
  - `--set <token>`
  - `--remove`
  - `--status`
  - `--instance <url>`
  - `--reset-instance`
- add GitLab integration to the interactive `viwo config` menu
- in `viwo start`, detect GitLab URLs and offer token setup when needed
- fix the interactive GitLab auto-detect flow so it pauses on the result screen and clearly says `Press Enter to go back to GitLab settings...`

### Tests / Docs
- add `packages/core/src/managers/__tests__/gitlab-manager.test.ts`
- update `CLAUDE.md`

## Verification
- `bun run typecheck`
- `cd packages/core && bun test`
- `bun run build`
- `bun packages/cli/src/cli.ts config gitlab --status`

Closes #123
