### PR TITLE
feat: add preAgent hook in viwo.yml for in-container setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,18 +139,25 @@ VIWO automatically detects and loads project-specific configuration from the rep
 - **Schema validation**: Validated using Zod schemas in `packages/core/src/schemas.ts`
 - **Supported configuration**:
     - `postInstall`: Array of shell commands to run after git worktree creation
-        - Commands execute in the worktree directory
-        - Commands run before agent initialization
+        - Commands execute in the worktree directory (on the host)
+        - Commands run before the container starts
         - If any command fails, session initialization fails and error is reported
-        - Example use cases: dependency installation, environment setup, build steps
+        - Example use cases: host-side setup, env file generation, pre-build steps
+    - `preAgent`: Array of shell commands to run inside the container before Claude Code starts
+        - Commands execute in `/workspace` inside the Docker container
+        - Commands run after credentials and git are configured but before Claude launches
+        - If any command fails, the container exits before Claude starts
+        - Example use cases: installing dependencies (`npm install`, `bun install`), building (`npm run build`), or any other setup Claude needs available during its work
 
 **Example configuration**:
 
 ```yaml
 postInstall:
-    - npm install
-    - npm run build
     - cp .env.example .env
+
+preAgent:
+    - bun install
+    - bun run build
 ```
 
 **Implementation**:

--- a/packages/agents/claude-code/claude-bootstrap.sh
+++ b/packages/agents/claude-code/claude-bootstrap.sh
@@ -97,6 +97,18 @@ cat > "${SETTINGS_DIR}/settings.json" <<'SETTINGS_EOF'
 }
 SETTINGS_EOF
 
+# --- Run pre-agent commands ---
+
+if [ -n "${VIWO_PRE_AGENT_COMMANDS:-}" ]; then
+  echo "Running pre-agent setup commands..."
+  cd /workspace
+  while IFS= read -r cmd; do
+    echo "+ $cmd"
+    eval "$cmd"
+  done < <(node -e "JSON.parse(process.env.VIWO_PRE_AGENT_COMMANDS).forEach(c => console.log(c))")
+  unset VIWO_PRE_AGENT_COMMANDS
+fi
+
 # --- Build Claude command ---
 
 CLAUDE_CMD="claude --dangerously-skip-permissions"

--- a/packages/core/src/managers/agent-manager.ts
+++ b/packages/core/src/managers/agent-manager.ts
@@ -22,6 +22,7 @@ export interface InitializeAgentOptions {
     sessionId: number;
     worktreePath: string;
     config: AgentConfig;
+    preAgentCommands?: string[];
 }
 
 export interface InitializeAgentResult {
@@ -68,7 +69,10 @@ const getGitUserConfig = (): { name: string; email: string } | null => {
     return null;
 };
 
-const buildClaudeEnv = (config: AgentConfig): Record<string, string> => {
+const buildClaudeEnv = (
+    config: AgentConfig,
+    preAgentCommands?: string[]
+): Record<string, string> => {
     const env: Record<string, string> = {
         VIWO_PROMPT: config.initialPrompt,
         CLAUDE_CODE_SANDBOXED: '1',
@@ -76,6 +80,10 @@ const buildClaudeEnv = (config: AgentConfig): Record<string, string> => {
 
     if (config.model) {
         env.VIWO_MODEL = config.model;
+    }
+
+    if (preAgentCommands && preAgentCommands.length > 0) {
+        env.VIWO_PRE_AGENT_COMMANDS = JSON.stringify(preAgentCommands);
     }
 
     const githubToken = getGitHubToken();
@@ -99,8 +107,9 @@ const startClaudeContainer = async (options: {
     worktreePath: string;
     config: AgentConfig;
     env: Record<string, string>;
+    preAgentCommands?: string[];
 }): Promise<InitializeAgentResult> => {
-    const { sessionId, worktreePath, config, env } = options;
+    const { sessionId, worktreePath, config, env, preAgentCommands } = options;
 
     const imageExists = await checkImageExists({ image: CLAUDE_CODE_IMAGE });
     if (!imageExists) {
@@ -108,7 +117,7 @@ const startClaudeContainer = async (options: {
     }
 
     const containerName = generateContainerName(sessionId);
-    const claudeEnv = buildClaudeEnv(config);
+    const claudeEnv = buildClaudeEnv(config, preAgentCommands);
 
     const statePath = await ensureContainerStatePath(sessionId);
 
@@ -206,6 +215,7 @@ const initializeClaudeCodeWithApiKey = async (
         worktreePath: options.worktreePath,
         config: options.config,
         env: { ANTHROPIC_API_KEY: apiKey },
+        preAgentCommands: options.preAgentCommands,
     });
 };
 
@@ -248,6 +258,7 @@ const initializeClaudeCodeWithOAuth = async (
             VIWO_OAUTH_CREDENTIALS: credentialsFile,
             VIWO_OAUTH_CONFIG: claudeConfig,
         },
+        preAgentCommands: options.preAgentCommands,
     });
 };
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -102,6 +102,7 @@ export const StartContainerOptionsSchema = z.object({
     prompt: z.string().min(1),
     agent: AgentTypeSchema.default('claude-code'),
     model: z.string().optional(),
+    preAgentCommands: z.array(z.string()).optional(),
 });
 export type StartContainerOptions = z.infer<typeof StartContainerOptionsSchema>;
 
@@ -165,6 +166,7 @@ export type ViwoConfig = z.infer<typeof ViwoConfigSchema>;
  */
 export const ProjectConfigSchema = z.object({
     postInstall: z.array(z.string()).optional(),
+    preAgent: z.array(z.string()).optional(),
 });
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
 

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -179,6 +179,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                 type: validated.agent ?? 'claude-code',
                 model: validated.model,
             },
+            preAgentCommands: validated.preAgentCommands,
         });
 
         return {
@@ -230,6 +231,9 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                 // Expand GitHub issue URLs in prompt
                 const expandedPrompt = await expandPromptWithIssues(validatedOptions.prompt);
 
+                // Load pre-agent commands from project config
+                const projectConfig = loadProjectConfig({ repoPath: worktreeResult.repoPath });
+
                 // Phase 2: Start container
                 const containerResult = await startContainerPhase({
                     sessionId: worktreeResult.sessionId,
@@ -237,6 +241,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                     prompt: expandedPrompt,
                     agent: validatedOptions.agent,
                     model: getPreferredModel() ?? 'sonnet',
+                    preAgentCommands: projectConfig?.preAgent,
                 });
 
                 worktreeSession.containerName = containerResult.containerName;


### PR DESCRIPTION
## Summary
- Adds a `preAgent` hook to `viwo.yml` that runs shell commands **inside the Docker container** before Claude Code starts, enabling dependency installation (`bun install`, `npm install`) and build steps that Claude needs available during its work
- Commands are JSON-encoded as `VIWO_PRE_AGENT_COMMANDS` env var, decoded and executed in `/workspace` by `claude-bootstrap.sh` using Node.js; any failure exits the container before Claude launches
- Complements the existing `postInstall` hook (host-side, pre-container) with a container-side counterpart; `StartContainerOptions` also exposes `preAgentCommands` for direct SDK usage

Closes #127

## Test plan
- [ ] Add `preAgent: [bun install]` to a repo's `viwo.yml` and run `viwo start` — verify commands execute inside the container before Claude's prompt appears
- [ ] Verify a failing `preAgent` command prevents Claude from starting and exits the container
- [ ] Verify sessions with no `preAgent` key are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)