### PR TITLE
fix: validate glab token auto-detection output

### DIFF
--- a/packages/core/src/managers/__tests__/gitlab-manager.test.ts
+++ b/packages/core/src/managers/__tests__/gitlab-manager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import {
+    extractGitLabTokenFromGlabOutput,
     getGitLabApiBaseUrl,
     getGitLabInstanceBaseUrl,
     parseGitLabResourceUrls,
@@ -80,5 +81,31 @@ describe('gitlab-manager', () => {
         process.env.GITLAB_TOKEN = 'glpat-test-token';
 
         expect(resolveGitLabTokenFromEnv()).toBe('glpat-test-token');
+    });
+
+    test('extracts a plain token from glab output', () => {
+        expect(extractGitLabTokenFromGlabOutput('glpat-test-token\n')).toBe('glpat-test-token');
+    });
+
+    test('extracts token from glab auth status output', () => {
+        const output = [
+            'gitlab.com',
+            '  ✓ Logged in as hal',
+            '  Token: glpat-test-token',
+        ].join('\n');
+
+        expect(extractGitLabTokenFromGlabOutput(output)).toBe('glpat-test-token');
+    });
+
+    test('rejects glab help text as a token', () => {
+        const output = [
+            "Manage glab's authentication state.",
+            '',
+            'USAGE',
+            '',
+            '  glab auth <command> [command] [--flags]',
+        ].join('\n');
+
+        expect(extractGitLabTokenFromGlabOutput(output)).toBeNull();
     });
 });

--- a/packages/core/src/managers/gitlab-manager.ts
+++ b/packages/core/src/managers/gitlab-manager.ts
@@ -208,11 +208,60 @@ export const expandPromptWithGitLabResources = async (prompt: string): Promise<s
     return expandedPrompt;
 };
 
+export const extractGitLabTokenFromGlabOutput = (output: string): string | null => {
+    const trimmed = output.trim();
+    if (!trimmed) return null;
+
+    const lower = trimmed.toLowerCase();
+    if (
+        lower.includes("manage glab's authentication state") ||
+        lower.includes('usage') ||
+        lower.includes('commands') ||
+        lower.includes('show help for this command')
+    ) {
+        return null;
+    }
+
+    const lines = trimmed
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+    if (lines.length === 1 && !/\s/.test(lines[0]!)) {
+        return lines[0]!;
+    }
+
+    for (const line of lines) {
+        const tokenMatch = line.match(/(?:token|personal access token)\s*:?\s+([^\s]+)/i);
+        if (tokenMatch?.[1] && !/\s/.test(tokenMatch[1])) {
+            return tokenMatch[1];
+        }
+    }
+
+    for (const line of [...lines].reverse()) {
+        if (!/\s/.test(line)) {
+            return line;
+        }
+    }
+
+    return null;
+};
+
 export const resolveGitLabTokenFromGlabCli = async (): Promise<string | null> => {
     const configuredHost = new URL(getGitLabInstanceBaseUrl()).host;
     const commands = configuredHost === 'gitlab.com'
-        ? [['glab', 'auth', 'token'], ['glab', 'auth', 'token', '--hostname', configuredHost]]
-        : [['glab', 'auth', 'token', '--hostname', configuredHost], ['glab', 'auth', 'token']];
+        ? [
+              ['glab', 'auth', 'token'],
+              ['glab', 'auth', 'token', '--hostname', configuredHost],
+              ['glab', 'auth', 'status', '--show-token'],
+              ['glab', 'auth', 'status', '--hostname', configuredHost, '--show-token'],
+          ]
+        : [
+              ['glab', 'auth', 'token', '--hostname', configuredHost],
+              ['glab', 'auth', 'status', '--hostname', configuredHost, '--show-token'],
+              ['glab', 'auth', 'token'],
+              ['glab', 'auth', 'status', '--show-token'],
+          ];
 
     for (const command of commands) {
         try {
@@ -220,8 +269,11 @@ export const resolveGitLabTokenFromGlabCli = async (): Promise<string | null> =>
             const output = await new Response(proc.stdout).text();
             const exitCode = await proc.exited;
 
-            if (exitCode === 0 && output.trim()) {
-                return output.trim();
+            if (exitCode === 0) {
+                const token = extractGitLabTokenFromGlabOutput(output);
+                if (token) {
+                    return token;
+                }
             }
         } catch {
             // glab not installed or not authed
@@ -241,6 +293,7 @@ export const gitlab = {
     parseGitLabResourceUrls,
     fetchGitLabResource,
     expandPromptWithGitLabResources,
+    extractGitLabTokenFromGlabOutput,
     resolveGitLabTokenFromGlabCli,
     resolveGitLabTokenFromEnv,
 };


### PR DESCRIPTION
## Summary
- reject `glab` help/usage output when auto-detecting GitLab tokens
- add fallback detection via `glab auth status --show-token`
- add tests for plain token output, status output, and help text rejection

## Related
- Closes #131

## Testing
- `cd packages/core && bun test src/managers/__tests__/gitlab-manager.test.ts`
