### PR TITLE
feat: automate Claude Code Docker image publish on version tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,41 @@
+name: Publish Claude Code Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Claude Code image
+        uses: docker/build-push-action@v6
+        with:
+          context: packages/agents/claude-code
+          file: packages/agents/claude-code/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            overseedai/viwo-claude-code:${{ steps.version.outputs.version }}
+            overseedai/viwo-claude-code:latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,15 +60,11 @@ To release a new version:
     git push origin vX.Y.Z
     ```
 
-3. **GitHub Actions workflow** (`.github/workflows/release.yml`):
-    - Triggered on tag push matching `v*`
-    - Builds binaries for all platforms (Linux, macOS, Windows)
-    - Uses native GitHub runners for platform-specific binaries (macOS binaries are built on macOS runners, Windows on Windows, Linux on Linux)
-    - Pins Bun to a known-good version for release builds
-    - Creates checksums
-    - Creates GitHub release with binaries attached
+3. **GitHub Actions workflows** triggered on tag push matching `v*`:
+    - `.github/workflows/release.yml` — Builds CLI binaries for all platforms (Linux, macOS, Windows) using native GitHub runners, creates checksums, and publishes a GitHub release with binaries attached. Pins Bun to a known-good version.
+    - `.github/workflows/docker-publish.yml` — Builds and publishes the Claude Code runtime image (`packages/agents/claude-code/Dockerfile`) to Docker Hub as `overseedai/viwo-claude-code:<version>` and `overseedai/viwo-claude-code:latest`. Multi-arch (`linux/amd64`, `linux/arm64`). Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo secrets.
 
-**Important**: Always bump package.json versions before creating git tags to keep them in sync.
+**Important**: Always bump package.json versions before creating git tags to keep them in sync. Also update `CLAUDE_CODE_IMAGE` in `packages/core/src/managers/docker-manager.ts` to reference the new version tag so VIWO pulls the matching image.
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docker-publish.yml` that builds the Claude Code runtime image (`packages/agents/claude-code/Dockerfile`) and pushes it to Docker Hub as `overseedai/viwo-claude-code:<version>` and `:latest` on every `v*` tag push.
- Multi-arch build (`linux/amd64`, `linux/arm64`) via Buildx/QEMU; auth via `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets.
- Updates `CLAUDE.md` release docs to describe the new workflow and remind maintainers to bump `CLAUDE_CODE_IMAGE` in `docker-manager.ts` alongside the package.json versions so the image tag in code stays aligned with the published image.

Closes OverseedAI/viwo#130

## Test plan
- [ ] Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the repo
- [ ] Push a test tag and confirm the workflow runs and both `:<version>` and `:latest` tags appear on Docker Hub
- [ ] Pull the published image on both amd64 and arm64 hosts to verify multi-arch
- [ ] Confirm `viwo start` still pulls and runs the image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)