### PR TITLE
feat: support custom bind mounts via viwo.yml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,12 @@ VIWO automatically detects and loads project-specific configuration from the rep
         - Commands run before the container starts
         - If any command fails, session initialization fails and error is reported
         - Example use cases: host-side setup, env file generation, pre-build steps
+    - `binds`: Array of custom bind mounts to expose host directories inside the container
+        - Each entry is either a Docker-style string (`"host:container"` or `"host:container:ro"`) or an object (`{ source, target, readonly? }`)
+        - Host paths may be absolute, use `~` for the user's home directory, or be relative to the repository root
+        - Container paths must be absolute
+        - Mounts are applied on top of the built-in `/workspace`, `/repo-git`, and `/tmp/viwo-state` binds
+        - Resolved via `resolveCustomBinds()` in `project-config-manager.ts` and threaded through `viwo.start()` → `initializeAgent()` → `createContainer()` as `additionalBinds`
     - `preAgent`: Array of shell commands to run inside the container before Claude Code starts
         - Commands execute in `/workspace` inside the Docker container
         - Commands run after credentials and git are configured but before Claude launches
@@ -159,6 +165,13 @@ postInstall:
 preAgent:
     - bun install
     - bun run build
+
+binds:
+    - ~/.cache/huggingface:/root/.cache/huggingface
+    - ./shared-data:/shared:ro
+    - source: ~/models
+      target: /models
+      readonly: true
 ```
 
 **Implementation**:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Well, **VIWO** (**Vi**rtual **Wo**rkspaces) might just be your solution:
     - [Installation](#installation)
     - [Quick Start](#quick-start)
     - [Post Install Hooks](#post-install-hooks)
+    - [Custom Bind Mounts](#custom-bind-mounts)
     - [How it works](#how-it-works)
     - [Security](#security)
     - [🚀 Development Guidelines](#-development-guidelines)
@@ -122,6 +123,28 @@ postInstall:
 
     # Copy environment file
     - cp .env.example .env
+```
+
+## Custom Bind Mounts
+
+You can expose extra host directories inside the Claude Code container by adding
+a `binds` entry to `viwo.yml`. This is useful for sharing caches, model weights,
+datasets, or any other data you'd rather not re-create inside the container.
+
+Host paths may be absolute, use `~` for your home directory, or be relative to
+the repository root. Container paths must be absolute. Append `:ro` (or set
+`readonly: true`) for read-only mounts.
+
+```yaml
+binds:
+    # String form (Docker-style)
+    - ~/.cache/huggingface:/root/.cache/huggingface
+    - ./shared-data:/shared:ro
+
+    # Object form
+    - source: ~/models
+      target: /models
+      readonly: true
 ```
 
 ## How it works

--- a/packages/core/src/managers/__tests__/project-config-manager.test.ts
+++ b/packages/core/src/managers/__tests__/project-config-manager.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
-import { loadProjectConfig, hasProjectConfig } from '../project-config-manager';
-import { tmpdir } from 'os';
+import { loadProjectConfig, hasProjectConfig, resolveCustomBinds } from '../project-config-manager';
+import { homedir, tmpdir } from 'os';
 
 describe('project-config-manager', () => {
     let testDir: string;
@@ -81,6 +81,83 @@ describe('project-config-manager', () => {
         test('throws error for invalid schema', () => {
             writeFileSync(join(testDir, 'viwo.yml'), 'postInstall: "not an array"');
             expect(() => loadProjectConfig({ repoPath: testDir })).toThrow();
+        });
+
+        test('parses binds in string and object form', () => {
+            writeFileSync(
+                join(testDir, 'viwo.yml'),
+                [
+                    'binds:',
+                    '  - /host/data:/data',
+                    '  - /host/cache:/cache:ro',
+                    '  - source: ~/models',
+                    '    target: /models',
+                    '    readonly: true',
+                ].join('\n')
+            );
+            const result = loadProjectConfig({ repoPath: testDir });
+            expect(result?.binds).toHaveLength(3);
+            expect(result?.binds?.[0]).toBe('/host/data:/data');
+            expect(result?.binds?.[2]).toEqual({
+                source: '~/models',
+                target: '/models',
+                readonly: true,
+            });
+        });
+    });
+
+    describe('resolveCustomBinds', () => {
+        test('resolves string form with and without mode', () => {
+            const result = resolveCustomBinds({
+                binds: ['/host/data:/data', '/host/cache:/cache:ro'],
+                repoPath: testDir,
+            });
+            expect(result).toEqual(['/host/data:/data', '/host/cache:/cache:ro']);
+        });
+
+        test('resolves object form with readonly', () => {
+            const result = resolveCustomBinds({
+                binds: [
+                    { source: '/host/data', target: '/data' },
+                    { source: '/host/models', target: '/models', readonly: true },
+                ],
+                repoPath: testDir,
+            });
+            expect(result).toEqual(['/host/data:/data', '/host/models:/models:ro']);
+        });
+
+        test('expands tilde in host paths', () => {
+            const result = resolveCustomBinds({
+                binds: ['~/data:/data'],
+                repoPath: testDir,
+            });
+            expect(result[0]).toBe(`${homedir()}/data:/data`);
+        });
+
+        test('resolves relative host paths against repo root', () => {
+            const result = resolveCustomBinds({
+                binds: ['./data:/data'],
+                repoPath: testDir,
+            });
+            expect(result[0]).toBe(`${testDir}/data:/data`);
+        });
+
+        test('throws when target is not absolute', () => {
+            expect(() =>
+                resolveCustomBinds({
+                    binds: [{ source: '/host/data', target: 'data' }],
+                    repoPath: testDir,
+                })
+            ).toThrow(/absolute/);
+        });
+
+        test('throws on malformed string bind', () => {
+            expect(() =>
+                resolveCustomBinds({
+                    binds: ['just-one-part'],
+                    repoPath: testDir,
+                })
+            ).toThrow(/Invalid bind/);
         });
     });
 });

--- a/packages/core/src/managers/agent-manager.ts
+++ b/packages/core/src/managers/agent-manager.ts
@@ -23,6 +23,7 @@ export interface InitializeAgentOptions {
     worktreePath: string;
     config: AgentConfig;
     preAgentCommands?: string[];
+    customBinds?: string[];
 }
 
 export interface InitializeAgentResult {
@@ -122,8 +123,9 @@ const startClaudeContainer = async (options: {
     config: AgentConfig;
     env: Record<string, string>;
     preAgentCommands?: string[];
+    customBinds?: string[];
 }): Promise<InitializeAgentResult> => {
-    const { sessionId, worktreePath, config, env, preAgentCommands } = options;
+    const { sessionId, worktreePath, config, env, preAgentCommands, customBinds } = options;
 
     const imageExists = await checkImageExists({ image: CLAUDE_CODE_IMAGE });
     if (!imageExists) {
@@ -146,7 +148,11 @@ const startClaudeContainer = async (options: {
         env: { ...env, ...claudeEnv },
         tty: true,
         openStdin: true,
-        additionalBinds: [`${statePath}:/tmp/viwo-state`, `${gitInfo.repoGitDir}:/repo-git`],
+        additionalBinds: [
+            `${statePath}:/tmp/viwo-state`,
+            `${gitInfo.repoGitDir}:/repo-git`,
+            ...(customBinds ?? []),
+        ],
     });
 
     const initialChat: NewChat = {
@@ -230,6 +236,7 @@ const initializeClaudeCodeWithApiKey = async (
         config: options.config,
         env: { ANTHROPIC_API_KEY: apiKey },
         preAgentCommands: options.preAgentCommands,
+        customBinds: options.customBinds,
     });
 };
 
@@ -273,6 +280,7 @@ const initializeClaudeCodeWithOAuth = async (
             VIWO_OAUTH_CONFIG: claudeConfig,
         },
         preAgentCommands: options.preAgentCommands,
+        customBinds: options.customBinds,
     });
 };
 

--- a/packages/core/src/managers/project-config-manager.ts
+++ b/packages/core/src/managers/project-config-manager.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join, resolve } from 'path';
 import YAML from 'yaml';
-import { ProjectConfigSchema, type ProjectConfig } from '../schemas';
+import { ProjectConfigSchema, type CustomBind, type ProjectConfig } from '../schemas';
+import { expandTilde } from '../utils/paths';
 
 export interface LoadProjectConfigOptions {
     repoPath: string;
@@ -54,8 +55,80 @@ export const hasProjectConfig = (options: LoadProjectConfigOptions): boolean => 
     return configFiles.some((filename) => existsSync(join(repoPath, filename)));
 };
 
+export interface ResolveCustomBindsOptions {
+    binds: CustomBind[];
+    repoPath: string;
+}
+
+/**
+ * Normalize a `binds` config entry into a Docker bind string
+ * (`hostPath:containerPath[:ro]`).
+ *
+ * - Accepts string form (`"./data:/data"` or `"./data:/data:ro"`) or object form
+ *   (`{ source, target, readonly }`).
+ * - Expands `~` in host paths.
+ * - Resolves relative host paths against the repo root so they behave
+ *   predictably regardless of where `viwo` is invoked.
+ * - Container paths must be absolute.
+ */
+export const resolveCustomBinds = (options: ResolveCustomBindsOptions): string[] => {
+    const { binds, repoPath } = options;
+
+    return binds.map((bind) => {
+        let source: string;
+        let target: string;
+        let mode: string | undefined;
+
+        if (typeof bind === 'string') {
+            // Split from the right so Windows-style "C:\foo:/bar" still parses.
+            // Expected forms: "src:dst" or "src:dst:ro"
+            const parts = bind.split(':');
+            if (parts.length < 2) {
+                throw new Error(
+                    `Invalid bind "${bind}": expected "source:target" or "source:target:ro"`
+                );
+            }
+            if (parts.length === 2) {
+                source = parts[0]!;
+                target = parts[1]!;
+            } else {
+                // Last segment may be a mode flag (ro/rw); otherwise treat as part of target path
+                const last = parts[parts.length - 1]!;
+                if (last === 'ro' || last === 'rw') {
+                    mode = last;
+                    target = parts[parts.length - 2]!;
+                    source = parts.slice(0, parts.length - 2).join(':');
+                } else {
+                    target = last;
+                    source = parts.slice(0, parts.length - 1).join(':');
+                }
+            }
+        } else {
+            source = bind.source;
+            target = bind.target;
+            if (bind.readonly) mode = 'ro';
+        }
+
+        if (!source || !target) {
+            throw new Error(`Invalid bind: source and target are required`);
+        }
+
+        if (!isAbsolute(target)) {
+            throw new Error(`Invalid bind target "${target}": must be an absolute path`);
+        }
+
+        const expandedSource = expandTilde(source);
+        const resolvedSource = isAbsolute(expandedSource)
+            ? expandedSource
+            : resolve(repoPath, expandedSource);
+
+        return mode ? `${resolvedSource}:${target}:${mode}` : `${resolvedSource}:${target}`;
+    });
+};
+
 // Namespace export for consistency with other managers
 export const projectConfig = {
     loadProjectConfig,
     hasProjectConfig,
+    resolveCustomBinds,
 };

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -103,6 +103,7 @@ export const StartContainerOptionsSchema = z.object({
     agent: AgentTypeSchema.default('claude-code'),
     model: z.string().optional(),
     preAgentCommands: z.array(z.string()).optional(),
+    customBinds: z.array(z.string()).optional(),
 });
 export type StartContainerOptions = z.infer<typeof StartContainerOptionsSchema>;
 
@@ -164,9 +165,22 @@ export type ViwoConfig = z.infer<typeof ViwoConfigSchema>;
 /**
  * Project configuration schemas (from viwo.yml/viwo.yaml)
  */
+export const CustomBindObjectSchema = z.object({
+    source: z.string().min(1),
+    target: z.string().min(1),
+    readonly: z.boolean().optional(),
+});
+export type CustomBindObject = z.infer<typeof CustomBindObjectSchema>;
+
+// A bind can be either a Docker-style string ("src:dst" or "src:dst:ro")
+// or an object form for clarity.
+export const CustomBindSchema = z.union([z.string().min(1), CustomBindObjectSchema]);
+export type CustomBind = z.infer<typeof CustomBindSchema>;
+
 export const ProjectConfigSchema = z.object({
     postInstall: z.array(z.string()).optional(),
     preAgent: z.array(z.string()).optional(),
+    binds: z.array(CustomBindSchema).optional(),
 });
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
 

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -37,7 +37,7 @@ import { Database } from 'bun:sqlite';
 import { mkdirSync, rmSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { sessionToWorktreeSession } from './utils/types';
-import { loadProjectConfig } from './managers/project-config-manager';
+import { loadProjectConfig, resolveCustomBinds } from './managers/project-config-manager';
 import { getPreferredModel } from './managers/config-manager';
 import { expandPromptWithIssues } from './managers/github-manager';
 import { expandPromptWithGitLabResources } from './managers/gitlab-manager';
@@ -181,6 +181,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                 model: validated.model,
             },
             preAgentCommands: validated.preAgentCommands,
+            customBinds: validated.customBinds,
         });
 
         return {
@@ -235,8 +236,16 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                     promptWithGitHubIssues
                 );
 
-                // Load pre-agent commands from project config
+                // Load pre-agent commands and custom binds from project config
                 const projectConfig = loadProjectConfig({ repoPath: worktreeResult.repoPath });
+
+                const customBinds =
+                    projectConfig?.binds && projectConfig.binds.length > 0
+                        ? resolveCustomBinds({
+                              binds: projectConfig.binds,
+                              repoPath: worktreeResult.repoPath,
+                          })
+                        : undefined;
 
                 // Phase 2: Start container
                 const containerResult = await startContainerPhase({
@@ -246,6 +255,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                     agent: validatedOptions.agent,
                     model: getPreferredModel() ?? 'sonnet',
                     preAgentCommands: projectConfig?.preAgent,
+                    customBinds,
                 });
 
                 worktreeSession.containerName = containerResult.containerName;

--- a/viwo.example.yml
+++ b/viwo.example.yml
@@ -17,3 +17,18 @@ postInstall:
   # Any other setup commands your project needs
   # - docker-compose up -d
   # - npx prisma generate
+
+# Custom bind mounts exposed inside the Claude Code container.
+# Host paths may be absolute, use `~` for your home directory, or be
+# relative to the repository root. Container paths must be absolute.
+# Append `:ro` (or set `readonly: true`) for read-only mounts.
+#
+# binds:
+#   # String form (Docker-style)
+#   - ~/.cache/huggingface:/root/.cache/huggingface
+#   - ./shared-data:/shared:ro
+#
+#   # Object form
+#   - source: ~/models
+#     target: /models
+#     readonly: true


### PR DESCRIPTION
## Summary
- Adds a `binds` field to `viwo.yml` so users can mount extra host directories (caches, model weights, datasets, etc.) into the Claude Code container
- Supports Docker-style string form (`host:container[:ro]`) and object form (`{ source, target, readonly }`), with `~` expansion and relative-to-repo host path resolution
- Threads resolved binds through `viwo.start()` → `initializeAgent()` → `createContainer()` on top of the existing `/workspace`, `/repo-git`, and `/tmp/viwo-state` mounts (both API-key and OAuth auth paths)
- New `resolveCustomBinds()` helper with unit tests covering parsing, mode flags, tilde/relative resolution, and validation errors; docs updated in README, CLAUDE.md, and viwo.example.yml

Closes #129

## Test plan
- [ ] `bun run typecheck`
- [ ] `cd packages/core && bun test project-config-manager`
- [ ] End-to-end: start a session with a `binds` entry in `viwo.yml` and confirm the mount is visible inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)