### PR TITLE
fix: return to session list immediately after delete

### DIFF
--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -218,11 +218,6 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
                         removeContainers: true,
                     });
                     console.log(chalk.green('✓ Session deleted successfully'));
-                    console.log();
-                    console.log(chalk.gray('Press Enter to continue...'));
-                    await new Promise((resolve) => {
-                        process.stdin.once('data', resolve);
-                    });
                 } catch (error) {
                     console.error(
                         chalk.red('Failed to delete session:'),


### PR DESCRIPTION
## Summary
- Removes the "Press Enter to continue" prompt after a successful session delete in the interactive `viwo list`, so users are taken straight back to the session list instead of getting stuck at a blocking prompt.
- Error path still shows the error with a "Press Enter to continue" so the user has a chance to read it.

Closes #138

## Test plan
- [ ] `viwo list` → select a session → delete → confirm list is re-rendered without intermediate prompt
- [ ] Delete the only remaining session → confirm "No sessions found." empty state still works
- [ ] Trigger a delete failure (e.g. already-removed container) → confirm error is displayed with Enter-to-continue

🤖 Generated with [Claude Code](https://claude.com/claude-code)