### PR TITLE
feat: add workspace-first create flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,14 +291,18 @@ The `docker-manager.ts` provides `syncDockerState()` to keep the database in syn
 
 Commands in `packages/cli/src/commands/`:
 
-- `start` - Initialize new session with prompt and agent
+- `start` - Initialize a workspace and start an agent immediately
     - Interactive multiline prompt that supports pasting multiple lines
     - Press Enter on an empty line or Ctrl+D to finish entering prompt
     - Allows users to paste large blocks of text without triggering execution
     - After initialization, displays session details and exits automatically
     - Container continues running in the background
-- `list` - List all sessions in interactive mode
-    - Keyboard-navigable list using @inquirer/prompts with session details and actions (cd to worktree, delete, go back)
+- `create` - Create a workspace without starting an agent
+    - Runs the workspace creation flow and project `postInstall` hooks only
+    - In interactive mode, offers follow-up actions like starting the agent, opening in an IDE, or deleting the workspace
+    - In non-interactive mode, never launches the agent; use `viwo start` for the all-in-one flow
+- `list` - List all workspaces in interactive mode
+    - Keyboard-navigable list using @inquirer/prompts with workspace details and actions (start agent, attach to container, open in IDE, delete, go back)
 - `clean` - Clean up all completed, errored, stopped, or initializing sessions (marks as 'cleaned', removes worktrees, deletes associated local branches, and runs `git worktree prune` for affected repositories)
 - `auth` - Configure authentication method
     - Choose between Claude subscription (OAuth auto-detect) or Anthropic API key
@@ -382,9 +386,12 @@ Current test coverage focuses on:
 All CLI commands support fully non-interactive, flag-based execution for agent-driven workflows. When all required flags are provided, no interactive prompt is triggered.
 
 ```bash
-# Start a session non-interactively
+# Start a workspace + agent non-interactively
 viwo start --repo <id> --branch <name> --prompt "Your prompt here"
 viwo start --repo <id> --prompt-file ./prompt.txt
+
+# Create a workspace non-interactively (never launches an agent)
+viwo create --repo <id> --branch <name>
 
 # List sessions as JSON
 viwo list --json

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander';
 import {
     startCommand,
+    createCommand,
     listCommand,
     cleanCommand,
     repoCommand,
@@ -24,6 +25,7 @@ program
 
 // Register commands
 program.addCommand(startCommand);
+program.addCommand(createCommand);
 program.addCommand(listCommand);
 program.addCommand(cleanCommand);
 program.addCommand(repoCommand);

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -7,8 +7,8 @@ import { preflightChecksOrExit } from '../utils/prerequisites';
 import { execSync } from 'child_process';
 
 export const attachCommand = new Command('attach')
-    .description('Attach to a running Claude Code session via tmux')
-    .argument('[session-id]', 'Session ID to attach to')
+    .description('Attach to a running workspace container via tmux')
+    .argument('[workspace-id]', 'Workspace ID to attach to')
     .action(async (sessionId?: string) => {
         try {
             await preflightChecksOrExit({ requireGit: false });
@@ -19,21 +19,21 @@ export const attachCommand = new Command('attach')
             if (sessionId) {
                 targetSessionId = sessionId;
             } else {
-                // Show interactive list of running sessions
+                // Show interactive list of running workspaces
                 const sessions = await viwo.list({ status: SessionStatus.RUNNING });
 
                 if (sessions.length === 0) {
                     console.log();
-                    console.log(chalk.yellow('No running sessions found.'));
+                    console.log(chalk.yellow('No running workspaces found.'));
                     console.log(
-                        chalk.gray('Create a new session with: ') + chalk.cyan('viwo start')
+                        chalk.gray('Create a workspace with: ') + chalk.cyan('viwo create')
                     );
                     console.log();
                     process.exit(0);
                 }
 
                 const selectedId = await select({
-                    message: 'Select a session to attach to:',
+                    message: 'Select a workspace to attach to:',
                     choices: [
                         ...sessions.map((s) => ({
                             name: `${getCompositeStatusBadge(s)} ${s.branchName.padEnd(40)} ${chalk.gray(formatDate(s.createdAt))}`,
@@ -57,17 +57,17 @@ export const attachCommand = new Command('attach')
                 targetSessionId = selectedId;
             }
 
-            // Get the session
-            const session = await viwo.get(targetSessionId);
+            // Get the workspace
+            const workspace = await viwo.get(targetSessionId);
 
-            if (!session) {
-                console.error(chalk.red(`Session not found: ${targetSessionId}`));
+            if (!workspace) {
+                console.error(chalk.red(`Workspace not found: ${targetSessionId}`));
                 process.exit(1);
             }
 
             // Determine container name
             const containerName =
-                session.containerName ||
+                workspace.containerName ||
                 DockerManager.generateContainerName(parseInt(targetSessionId, 10));
 
             // Check if container exists and is running
@@ -77,7 +77,7 @@ export const attachCommand = new Command('attach')
 
             if (!exists) {
                 console.error(chalk.red(`Container ${containerName} does not exist.`));
-                console.log(chalk.gray('Run "viwo clean" to remove this session.'));
+                console.log(chalk.gray('Run "viwo clean" to remove this workspace.'));
                 process.exit(1);
             }
 
@@ -95,7 +95,7 @@ export const attachCommand = new Command('attach')
 
             // Print attach hint and run docker exec
             console.log();
-            console.log(chalk.dim(`Attaching to session ${targetSessionId} (${containerName})...`));
+            console.log(chalk.dim(`Attaching to workspace ${targetSessionId} (${containerName})...`));
             console.log(chalk.yellow('Detach with: Ctrl+B, D'));
             console.log();
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -59,7 +59,7 @@ const configureOAuth = async (): Promise<void> => {
     );
 
     const confirmed = await clack.confirm({
-        message: 'Use this subscription for VIWO sessions?',
+        message: 'Use this subscription for VIWO workspaces?',
     });
 
     if (clack.isCancel(confirmed) || !confirmed) {
@@ -69,7 +69,7 @@ const configureOAuth = async (): Promise<void> => {
 
     ConfigManager.setAuthMethod('oauth');
     clack.log.success('Authentication method set to Claude subscription.');
-    clack.log.info('Credentials will be read from your Claude Code login at each session start.');
+    clack.log.info('Credentials will be read from your Claude Code login each time an agent is started.');
 };
 
 const configureApiKey = async (): Promise<void> => {

--- a/packages/cli/src/commands/clean.ts
+++ b/packages/cli/src/commands/clean.ts
@@ -6,14 +6,14 @@ import { preflightChecksOrExit } from '../utils/prerequisites';
 
 export const cleanCommand = new Command('clean')
     .description(
-        'Clean up all completed, errored, stopped, or initializing sessions (removes worktrees, branches, and updates status)'
+        'Clean up all completed, errored, stopped, or initializing workspaces (removes worktrees, branches, and updates status)'
     )
     .option('--keep-worktree', 'Keep the worktree directories')
     .option('--keep-containers', 'Keep containers running')
     .option('--no-sync', 'Skip syncing Docker state before cleanup')
     .option(
         '--status <status>',
-        'Only clean sessions with specific status (completed, error, stopped, initializing)',
+        'Only clean workspaces with specific status (completed, error, stopped, initializing)',
         'completed,error,stopped,initializing'
     )
     .action(async (options) => {
@@ -21,7 +21,7 @@ export const cleanCommand = new Command('clean')
             // Run preflight checks before proceeding
             await preflightChecksOrExit();
 
-            const spinner = ora('Finding sessions to clean...').start();
+            const spinner = ora('Finding workspaces to clean...').start();
 
             // Sync Docker state with database before cleanup
             if (options.sync !== false) {
@@ -38,18 +38,18 @@ export const cleanCommand = new Command('clean')
             );
 
             if (sessionsToClean.length === 0) {
-                spinner.info(`No sessions found with status: ${statusFilter.join(', ')}`);
+                spinner.info(`No workspaces found with status: ${statusFilter.join(', ')}`);
                 return;
             }
 
-            spinner.text = `Found ${sessionsToClean.length} session(s) to clean...`;
+            spinner.text = `Found ${sessionsToClean.length} workspace(s) to clean...`;
 
             let successCount = 0;
             let errorCount = 0;
             const affectedRepoIds = new Set<number>();
 
             for (const session of sessionsToClean) {
-                spinner.text = `Cleaning session ${session.id} (${session.branchName})...`;
+                spinner.text = `Cleaning workspace ${session.id} (${session.branchName})...`;
 
                 try {
                     // Track which repositories are affected
@@ -72,7 +72,7 @@ export const cleanCommand = new Command('clean')
                     errorCount++;
                     console.error(
                         chalk.yellow(
-                            `\nWarning: Failed to clean session ${session.id}: ${error instanceof Error ? error.message : String(error)}`
+                            `\nWarning: Failed to clean workspace ${session.id}: ${error instanceof Error ? error.message : String(error)}`
                         )
                     );
                 }
@@ -98,9 +98,9 @@ export const cleanCommand = new Command('clean')
             }
 
             if (errorCount === 0) {
-                spinner.succeed(`Successfully cleaned ${successCount} session(s)!`);
+                spinner.succeed(`Successfully cleaned ${successCount} workspace(s)!`);
             } else {
-                spinner.warn(`Cleaned ${successCount} session(s), ${errorCount} failed`);
+                spinner.warn(`Cleaned ${successCount} workspace(s), ${errorCount} failed`);
             }
         } catch (error) {
             console.error(chalk.red(error instanceof Error ? error.message : String(error)));

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -795,7 +795,7 @@ const runAuthConfig = async (): Promise<void> => {
         console.log();
 
         const confirmed = await confirm({
-            message: 'Use this subscription for VIWO sessions?',
+            message: 'Use this subscription for VIWO workspaces?',
         });
 
         if (!confirmed) {
@@ -806,7 +806,7 @@ const runAuthConfig = async (): Promise<void> => {
 
         ConfigManager.setAuthMethod('oauth');
         console.log(chalk.green('✓ Authentication method set to Claude subscription'));
-        console.log(chalk.gray('  Credentials will be read from your Claude Code login at each session start.'));
+        console.log(chalk.gray('  Credentials will be read from your Claude Code login each time an agent is started.'));
         console.log();
     } else {
         const apiKey = await password({

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,0 +1,218 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import * as clack from '@clack/prompts';
+import { viwo, GitManager, type WorktreeSession } from '@viwo/core';
+import { preflightChecksOrExit } from '../utils/prerequisites';
+import { selectAndOpenIDE } from '../utils/ide-selector';
+import { launchAgentForSession } from '../utils/agent-launch';
+import { getStatusBadge } from '../utils/formatters';
+
+const printWorkspaceDetails = (workspace: WorktreeSession) => {
+    console.log();
+    console.log(chalk.bold('Workspace Details'));
+    console.log();
+    console.log(`  ${chalk.cyan('ID:')}         ${workspace.id}`);
+    console.log(`  ${chalk.cyan('Branch:')}     ${workspace.branchName}`);
+    console.log(`  ${chalk.cyan('Worktree:')}   ${workspace.worktreePath}`);
+    console.log(`  ${chalk.cyan('Status:')}     ${getStatusBadge(workspace.status)}`);
+    console.log();
+};
+
+const runPostCreateActions = async (workspace: WorktreeSession): Promise<void> => {
+    while (true) {
+        const action = await clack.select({
+            message: 'Workspace ready. What would you like to do?',
+            options: [
+                { label: 'Start agent', value: 'start-agent' },
+                { label: 'Open in IDE', value: 'open-ide' },
+                { label: 'Delete workspace', value: 'delete' },
+                { label: 'Exit', value: 'exit' },
+            ],
+        });
+
+        if (clack.isCancel(action) || action === 'exit') {
+            return;
+        }
+
+        if (action === 'start-agent') {
+            const spinner = clack.spinner();
+            try {
+                spinner.start('Starting agent...');
+                await launchAgentForSession({
+                    sessionId: workspace.id,
+                    worktreePath: workspace.worktreePath,
+                    repoPath: workspace.repoPath,
+                    agent: workspace.agent.type,
+                });
+                spinner.stop('Agent started successfully!');
+                const updated = await viwo.get(workspace.id);
+                if (updated?.containerName) {
+                    console.log();
+                    console.log(chalk.dim('Container is running in the background.'));
+                    console.log();
+                    console.log(`  Attach:  ${chalk.cyan(`viwo attach ${updated.id}`)}`);
+                    console.log(`  Detach:  ${chalk.dim('Ctrl+B, D (inside tmux)')}`);
+                    console.log();
+                }
+                return;
+            } catch (error) {
+                spinner.stop(
+                    error instanceof Error ? error.message : 'Failed to start agent.'
+                );
+            }
+            continue;
+        }
+
+        if (action === 'open-ide') {
+            await selectAndOpenIDE(workspace.worktreePath);
+            continue;
+        }
+
+        if (action === 'delete') {
+            const confirmDelete = await clack.select({
+                message: chalk.red(
+                    `Are you sure you want to delete workspace ${workspace.id.substring(0, 12)}?`
+                ),
+                options: [
+                    { label: 'No, cancel', value: false },
+                    { label: 'Yes, delete', value: true },
+                ],
+            });
+
+            if (clack.isCancel(confirmDelete) || !confirmDelete) {
+                continue;
+            }
+
+            await viwo.cleanup({
+                sessionId: workspace.id,
+                removeWorktree: true,
+                stopContainers: true,
+                removeContainers: true,
+            });
+            clack.log.success('Workspace deleted successfully.');
+            return;
+        }
+    }
+};
+
+export const createCommand = new Command('create')
+    .description('Create a new workspace without starting an AI agent')
+    .option('-r, --repo <id>', 'Repository ID to use')
+    .option('-b, --branch <branch>', 'Custom branch name')
+    .option('-e, --env <path>', 'Path to .env file to copy')
+    .option('--no-sync', 'Skip syncing Docker state before creating')
+    .action(async (options) => {
+        try {
+            await preflightChecksOrExit({ requireDocker: false });
+
+            if (options.sync !== false) {
+                try {
+                    await viwo.sync();
+                } catch {
+                    // Workspace creation should still work when Docker is unavailable.
+                }
+            }
+
+            const nonInteractive = Boolean(options.repo);
+
+            clack.intro(chalk.bgCyan(' viwo create '));
+
+            let repoId: number;
+            if (options.repo) {
+                repoId = parseInt(options.repo, 10);
+                if (isNaN(repoId)) {
+                    clack.cancel('Invalid repository ID');
+                    process.exit(1);
+                }
+            } else {
+                const repositories = viwo.repo.list({ archived: false, orderByRecentlyUsed: true });
+
+                if (repositories.length === 0) {
+                    clack.cancel('No repositories found.');
+                    console.log();
+                    console.log(chalk.yellow('Add a repository first:'));
+                    console.log(chalk.gray('  viwo repo add <path> --name <name>'));
+                    console.log();
+                    process.exit(1);
+                }
+
+                const selectedRepo = await clack.select({
+                    message: 'Select a repository',
+                    options: repositories.map((repo) => ({
+                        label: repo.name,
+                        value: repo.id,
+                        hint: repo.path,
+                    })),
+                });
+
+                if (clack.isCancel(selectedRepo)) {
+                    clack.cancel('Operation cancelled.');
+                    process.exit(0);
+                }
+
+                repoId = selectedRepo;
+            }
+
+            let branchName: string | undefined = options.branch;
+            if (branchName) {
+                const validationError = GitManager.validateBranchName(branchName);
+                if (validationError) {
+                    clack.log.error(chalk.red(validationError));
+                    process.exit(1);
+                }
+            } else if (!nonInteractive) {
+                const branchInput = await clack.text({
+                    message: 'Branch name',
+                    placeholder: 'Leave empty for auto-generated',
+                    validate: (value) => {
+                        if (!value || !value.trim()) return undefined;
+                        return GitManager.validateBranchName(value.trim());
+                    },
+                });
+
+                if (clack.isCancel(branchInput)) {
+                    clack.cancel('Operation cancelled.');
+                    process.exit(0);
+                }
+
+                if (branchInput && branchInput.trim()) {
+                    branchName = branchInput.trim();
+                }
+            }
+
+            const spinner = clack.spinner();
+            spinner.start('Creating workspace...');
+
+            const result = await viwo.createWorktree({
+                repoId,
+                branchName,
+                envFile: options.env,
+            });
+
+            const workspace = await viwo.get(String(result.sessionId));
+            if (!workspace) {
+                throw new Error('Workspace created but could not be loaded.');
+            }
+
+            spinner.stop('Workspace created successfully!');
+            printWorkspaceDetails(workspace);
+
+            if (nonInteractive) {
+                console.log(chalk.dim('Workspace is ready.'));
+                console.log();
+                console.log(chalk.gray('Next steps:'));
+                console.log(`  Browse workspaces: ${chalk.cyan('viwo list')}`);
+                console.log(`  Start agent:       ${chalk.cyan('viwo list')}`);
+                console.log(`  Delete workspace:  ${chalk.cyan('viwo clean')}`);
+                console.log();
+                clack.outro('Workspace ready!');
+                return;
+            }
+
+            await runPostCreateActions(workspace);
+            clack.outro('Workspace ready!');
+        } catch (error) {
+            clack.cancel(error instanceof Error ? error.message : String(error));
+            process.exit(1);
+        }
+    });

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,5 @@
 export { startCommand } from './start';
+export { createCommand } from './create';
 export { listCommand } from './list';
 export { cleanCommand } from './clean';
 export { repoCommand } from './repo';

--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -1,20 +1,48 @@
 import { select, Separator } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { SessionStatus, viwo, DockerManager, type WorktreeSession } from '@viwo/core';
-import { getCompositeStatusBadge, formatDate } from '../utils/formatters';
+import {
+    getAgentStatusBadge,
+    getCompositeStatusBadge,
+    getStatusBadge,
+    formatDate,
+} from '../utils/formatters';
 import { preflightChecksOrExit } from '../utils/prerequisites';
 import { selectAndOpenIDE } from '../utils/ide-selector';
+import { launchAgentForSession } from '../utils/agent-launch';
 import { execSync } from 'child_process';
+
+const getContainerName = (session: WorktreeSession): string =>
+    session.containerName || DockerManager.generateContainerName(parseInt(session.id, 10));
+
+const hasAttachableContainer = async (session: WorktreeSession): Promise<boolean> => {
+    if (!session.containerName && session.containers.length === 0) {
+        return false;
+    }
+
+    try {
+        return await DockerManager.containerExists({
+            containerId: getContainerName(session),
+        });
+    } catch {
+        return false;
+    }
+};
 
 const displaySessionDetails = async (session: WorktreeSession) => {
     console.clear();
     console.log();
-    console.log(chalk.bold.cyan('Session Details'));
+    console.log(chalk.bold.cyan('Workspace Details'));
     console.log(chalk.gray('═'.repeat(70)));
     console.log();
     console.log(chalk.bold('General'));
     console.log(chalk.gray('  ID:              '), session.id);
-    console.log(chalk.gray('  Status:          '), getCompositeStatusBadge(session));
+    console.log(chalk.gray('  Runtime Status:  '), getStatusBadge(session.status));
+    console.log(
+        chalk.gray('  Agent Status:    '),
+        getAgentStatusBadge(session.agentStatus ?? 'unknown')
+    );
+    console.log(chalk.gray('  Combined:        '), getCompositeStatusBadge(session));
     console.log(chalk.gray('  Created:         '), formatDate(session.createdAt));
     console.log(chalk.gray('  Last Activity:   '), formatDate(session.lastActivity));
     if (session.agentStateTimestamp) {
@@ -49,9 +77,16 @@ const displaySessionDetails = async (session: WorktreeSession) => {
         console.log();
     }
 
-    if (session.status !== SessionStatus.CLEANED) {
+    const attachableContainer = await hasAttachableContainer(session);
+    if (session.status !== SessionStatus.CLEANED && attachableContainer) {
         console.log(chalk.bold('Attach'));
         console.log(chalk.gray('  Command:         '), chalk.cyan(`viwo attach ${session.id}`));
+        console.log();
+    }
+
+    if (!attachableContainer && session.status !== SessionStatus.CLEANED) {
+        console.log(chalk.bold('Launch Agent'));
+        console.log(chalk.gray('  Action:          '), chalk.cyan('Start agent from this workspace'));
         console.log();
     }
 
@@ -84,11 +119,18 @@ const displaySessionDetails = async (session: WorktreeSession) => {
 };
 
 const handleSessionAction = async (session: WorktreeSession): Promise<'back' | 'exit'> => {
+    const attachableContainer = await hasAttachableContainer(session);
+
     const actions = [
+        {
+            name: '▶️  Start agent',
+            value: 'start-agent',
+            disabled: session.status === SessionStatus.CLEANED || attachableContainer,
+        },
         {
             name: '🔗 Attach to container',
             value: 'attach',
-            disabled: session.status === SessionStatus.CLEANED,
+            disabled: session.status === SessionStatus.CLEANED || !attachableContainer,
         },
         {
             name: '💻 Open in IDE',
@@ -101,7 +143,7 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
             disabled: !session.containerOutput,
         },
         {
-            name: '🗑️  Delete session',
+            name: '🗑️  Delete workspace',
             value: 'delete',
         },
         {
@@ -120,10 +162,31 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
     });
 
     switch (action) {
+        case 'start-agent': {
+            try {
+                await launchAgentForSession({
+                    sessionId: session.id,
+                    worktreePath: session.worktreePath,
+                    repoPath: session.repoPath,
+                    agent: session.agent.type,
+                });
+                console.log(chalk.green('✓ Agent started successfully'));
+            } catch (error) {
+                console.error(
+                    chalk.red('Failed to start agent:'),
+                    error instanceof Error ? error.message : String(error)
+                );
+            }
+            console.log();
+            console.log(chalk.gray('Press Enter to continue...'));
+            await new Promise((resolve) => {
+                process.stdin.once('data', resolve);
+            });
+            return 'back';
+        }
+
         case 'attach': {
-            const containerName =
-                session.containerName ||
-                DockerManager.generateContainerName(parseInt(session.id, 10));
+            const containerName = getContainerName(session);
 
             const exists = await DockerManager.containerExists({
                 containerId: containerName,
@@ -131,7 +194,7 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
 
             if (!exists) {
                 console.log(chalk.red(`Container ${containerName} no longer exists.`));
-                console.log(chalk.gray('Run "viwo clean" to remove this session.'));
+                console.log(chalk.gray('Run "viwo clean" to remove this workspace.'));
                 console.log();
                 console.log(chalk.gray('Press Enter to continue...'));
                 await new Promise((resolve) => {
@@ -152,7 +215,7 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
             }
 
             console.log();
-            console.log(chalk.dim(`Attaching to session ${session.id} (${containerName})...`));
+            console.log(chalk.dim(`Attaching to workspace ${session.id} (${containerName})...`));
             console.log(chalk.yellow('Detach with: Ctrl+B, D'));
             console.log();
             execSync(`docker exec -it ${containerName} tmux attach -t viwo`, {
@@ -201,7 +264,7 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
             console.log();
             const confirmDelete = await select({
                 message: chalk.red(
-                    `Are you sure you want to delete session ${session.id.substring(0, 12)}?`
+                    `Are you sure you want to delete workspace ${session.id.substring(0, 12)}?`
                 ),
                 choices: [
                     { name: 'No, cancel', value: false },
@@ -217,7 +280,7 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
                         stopContainers: true,
                         removeContainers: true,
                     });
-                    console.log(chalk.green('✓ Session deleted successfully'));
+                    console.log(chalk.green('✓ Workspace deleted successfully'));
                     console.log();
                     console.log(chalk.gray('Press Enter to continue...'));
                     await new Promise((resolve) => {
@@ -225,7 +288,7 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
                     });
                 } catch (error) {
                     console.error(
-                        chalk.red('Failed to delete session:'),
+                        chalk.red('Failed to delete workspace:'),
                         error instanceof Error ? error.message : String(error)
                     );
                     console.log();
@@ -272,16 +335,19 @@ export const runInteractiveList = async (options: { status?: SessionStatus; limi
             if (sessions.length === 0) {
                 console.clear();
                 console.log();
-                console.log(chalk.yellow('No sessions found.'));
-                console.log(chalk.gray('Create a new session with: ') + chalk.cyan('viwo start'));
+                console.log(chalk.yellow('No workspaces found.'));
+                console.log(
+                    chalk.gray('Create a new workspace with: ') + chalk.cyan('viwo create')
+                );
                 console.log();
                 break;
             }
 
             console.clear();
             console.log();
-            console.log(chalk.bold.cyan('VIWO Sessions'));
+            console.log(chalk.bold.cyan('VIWO Workspaces'));
             console.log(chalk.gray('Use arrow keys to navigate, Enter to select'));
+            console.log(chalk.gray('Left status = container/runtime, right status = coding agent'));
             console.log();
 
             const sessionChoices = sessions.map((session) => ({
@@ -291,7 +357,7 @@ export const runInteractiveList = async (options: { status?: SessionStatus; limi
             }));
 
             const selectedId = await select({
-                message: `Select a session (${sessions.length} total):`,
+                message: `Select a workspace (${sessions.length} total):`,
                 choices: [
                     ...sessionChoices,
                     new Separator(chalk.gray('─'.repeat(70))),

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -5,7 +5,7 @@ import { preflightChecksOrExit } from '../utils/prerequisites';
 import { runInteractiveList } from './list-interactive';
 
 export const listCommand = new Command('list')
-    .description('List all worktree sessions')
+    .description('List all workspaces')
     .option('-s, --status <status>', 'Filter by status')
     .option('-l, --limit <number>', 'Limit number of results', parseInt)
     .option('--json', 'Output as JSON (non-interactive)')

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,14 +1,13 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import * as clack from '@clack/prompts';
-import { readFileSync } from 'fs';
-import { viwo, ConfigManager, GitHubManager, GitLabManager, GitManager } from '@viwo/core';
+import { viwo, GitManager } from '@viwo/core';
 import { getStatusBadge } from '../utils/formatters';
 import { preflightChecksOrExit } from '../utils/prerequisites';
-import { multilineInput } from '../utils/multiline-input';
+import { preparePromptForLaunch } from '../utils/agent-launch';
 
 export const startCommand = new Command('start')
-    .description('Initialize a new worktree session with an AI agent')
+    .description('Create a workspace and start an AI agent')
     .option('-r, --repo <id>', 'Repository ID to use')
     .option('-a, --agent <agent>', 'AI agent to use', 'claude-code')
     .option('-b, --branch <branch>', 'Custom branch name')
@@ -22,17 +21,6 @@ export const startCommand = new Command('start')
         try {
             // Run preflight checks before proceeding
             await preflightChecksOrExit();
-
-            // Ensure authentication is configured before proceeding
-            if (!ConfigManager.isAuthConfigured()) {
-                console.log();
-                console.log(chalk.red('Authentication is not configured.'));
-                console.log();
-                console.log(chalk.yellow('Run the following command to set up authentication:'));
-                console.log(chalk.cyan('  viwo auth'));
-                console.log();
-                process.exit(1);
-            }
 
             // Sync Docker state with database before starting
             if (options.sync !== false) {
@@ -108,133 +96,17 @@ export const startCommand = new Command('start')
                 }
             }
 
-            // Step 3: Get prompt
-            let prompt: string;
+            // Step 3: Get prompt and prepare agent launch
+            const prompt = await preparePromptForLaunch({
+                prompt: options.prompt,
+                promptFile: options.promptFile,
+            });
 
-            if (options.prompt) {
-                prompt = options.prompt;
-            } else if (options.promptFile) {
-                try {
-                    prompt = readFileSync(options.promptFile, 'utf-8').trim();
-                } catch {
-                    clack.cancel(`Failed to read prompt file: ${options.promptFile}`);
-                    process.exit(1);
-                }
-
-                if (!prompt) {
-                    clack.cancel('Prompt file is empty');
-                    process.exit(1);
-                }
-            } else {
-                prompt = await multilineInput({
-                    message: 'Enter your prompt for the AI agent:',
-                });
-            }
-
-            // If prompt contains GitHub issue URLs and no token is stored, offer setup
-            const issueUrls = GitHubManager.parseIssueUrls(prompt);
-            if (issueUrls.length > 0 && !ConfigManager.hasGitHubToken()) {
-                clack.log.info(
-                    `Detected ${issueUrls.length} GitHub issue URL(s). A GitHub token is needed to fetch issue context.`
-                );
-
-                const setupChoice = await clack.select({
-                    message: 'Set up GitHub token now?',
-                    options: [
-                        { label: 'Auto-detect (gh CLI / env var)', value: 'auto' },
-                        { label: 'Enter token manually', value: 'manual' },
-                        { label: 'Skip — continue without issue context', value: 'skip' },
-                    ],
-                });
-
-                if (clack.isCancel(setupChoice)) {
-                    clack.cancel('Operation cancelled.');
-                    process.exit(0);
-                }
-
-                if (setupChoice === 'auto') {
-                    let resolved = await GitHubManager.resolveGitHubTokenFromGhCli();
-                    if (!resolved) resolved = GitHubManager.resolveGitHubTokenFromEnv();
-
-                    if (resolved) {
-                        ConfigManager.setGitHubToken(resolved);
-                        clack.log.success('GitHub token saved.');
-                    } else {
-                        clack.log.warn(
-                            'No token found. Install gh CLI (gh auth login) or set GITHUB_TOKEN env var.'
-                        );
-                    }
-                } else if (setupChoice === 'manual') {
-                    const tokenInput = await clack.password({
-                        message: 'Enter your GitHub personal access token:',
-                    });
-
-                    if (clack.isCancel(tokenInput)) {
-                        clack.cancel('Operation cancelled.');
-                        process.exit(0);
-                    }
-
-                    if (tokenInput && tokenInput.trim()) {
-                        ConfigManager.setGitHubToken(tokenInput.trim());
-                        clack.log.success('GitHub token saved.');
-                    }
-                }
-            }
-
-            const gitlabUrls = GitLabManager.parseGitLabResourceUrls(prompt);
-            if (gitlabUrls.length > 0 && !ConfigManager.hasGitLabToken()) {
-                clack.log.info(
-                    `Detected ${gitlabUrls.length} GitLab issue/MR URL(s). A GitLab token is needed to fetch context.`
-                );
-
-                const setupChoice = await clack.select({
-                    message: 'Set up GitLab token now?',
-                    options: [
-                        { label: 'Auto-detect (glab CLI / env var)', value: 'auto' },
-                        { label: 'Enter token manually', value: 'manual' },
-                        { label: 'Skip — continue without GitLab context', value: 'skip' },
-                    ],
-                });
-
-                if (clack.isCancel(setupChoice)) {
-                    clack.cancel('Operation cancelled.');
-                    process.exit(0);
-                }
-
-                if (setupChoice === 'auto') {
-                    let resolved = await GitLabManager.resolveGitLabTokenFromGlabCli();
-                    if (!resolved) resolved = GitLabManager.resolveGitLabTokenFromEnv();
-
-                    if (resolved) {
-                        ConfigManager.setGitLabToken(resolved);
-                        clack.log.success('GitLab token saved.');
-                    } else {
-                        clack.log.warn(
-                            'No token found. Install glab CLI (glab auth login) or set GITLAB_TOKEN env var.'
-                        );
-                    }
-                } else if (setupChoice === 'manual') {
-                    const tokenInput = await clack.password({
-                        message: 'Enter your GitLab personal access token:',
-                    });
-
-                    if (clack.isCancel(tokenInput)) {
-                        clack.cancel('Operation cancelled.');
-                        process.exit(0);
-                    }
-
-                    if (tokenInput && tokenInput.trim()) {
-                        ConfigManager.setGitLabToken(tokenInput.trim());
-                        clack.log.success('GitLab token saved.');
-                    }
-                }
-            }
-
-            // Create session
+            // Create workspace and start agent
             const spinner = clack.spinner();
-            spinner.start('Initializing worktree session...');
+            spinner.start('Initializing workspace and agent...');
 
-            const session = await viwo.start({
+            const workspace = await viwo.start({
                 repoId,
                 prompt,
                 agent: options.agent,
@@ -244,27 +116,27 @@ export const startCommand = new Command('start')
                 setupCommands: options.setup,
             });
 
-            spinner.stop('Session created successfully!');
+            spinner.stop('Workspace and agent started successfully!');
 
             console.log();
-            console.log(chalk.bold('Session Details'));
+            console.log(chalk.bold('Workspace Details'));
             console.log();
-            console.log(`  ${chalk.cyan('ID:')}         ${session.id}`);
-            console.log(`  ${chalk.cyan('Branch:')}     ${session.branchName}`);
-            console.log(`  ${chalk.cyan('Worktree:')}   ${session.worktreePath}`);
-            console.log(`  ${chalk.cyan('Agent:')}      ${session.agent.type}`);
-            console.log(`  ${chalk.cyan('Status:')}     ${getStatusBadge(session.status)}`);
-            if (session.containerName) {
-                console.log(`  ${chalk.cyan('Container:')}  ${session.containerName}`);
+            console.log(`  ${chalk.cyan('ID:')}         ${workspace.id}`);
+            console.log(`  ${chalk.cyan('Branch:')}     ${workspace.branchName}`);
+            console.log(`  ${chalk.cyan('Worktree:')}   ${workspace.worktreePath}`);
+            console.log(`  ${chalk.cyan('Agent:')}      ${workspace.agent.type}`);
+            console.log(`  ${chalk.cyan('Status:')}     ${getStatusBadge(workspace.status)}`);
+            if (workspace.containerName) {
+                console.log(`  ${chalk.cyan('Container:')}  ${workspace.containerName}`);
             }
 
             console.log();
             console.log(chalk.dim('Container is running in the background.'));
             console.log();
-            console.log(`  Attach:  ${chalk.cyan(`viwo attach ${session.id}`)}`);
+            console.log(`  Attach:  ${chalk.cyan(`viwo attach ${workspace.id}`)}`);
             console.log(`  Detach:  ${chalk.dim('Ctrl+B, D (inside tmux)')}`);
             console.log();
-            clack.outro('Session ready!');
+            clack.outro('Workspace ready!');
             process.exit(0);
         } catch (error) {
             clack.cancel(error instanceof Error ? error.message : String(error));

--- a/packages/cli/src/utils/__tests__/formatters.test.ts
+++ b/packages/cli/src/utils/__tests__/formatters.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect } from 'bun:test';
-import { formatDate } from '../formatters';
+import { getAgentStatusBadge, getCompositeStatusBadge, getStatusBadge, formatDate } from '../formatters';
+
+describe('status formatters', () => {
+    it('should render runtime status badges', () => {
+        expect(getStatusBadge('running')).toContain('running');
+        expect(getStatusBadge('completed')).toContain('completed');
+    });
+
+    it('should render agent status badges', () => {
+        expect(getAgentStatusBadge('working')).toContain('working');
+        expect(getAgentStatusBadge('awaiting_input')).toContain('awaiting_input');
+    });
+
+    it('should render combined runtime and agent status badges', () => {
+        const badge = getCompositeStatusBadge({
+            status: 'running',
+            agentStatus: 'working',
+        } as any);
+
+        expect(badge).toContain('running');
+        expect(badge).toContain('working');
+    });
+});
+
 
 describe('formatDate', () => {
     it('should format dates with seconds', () => {

--- a/packages/cli/src/utils/agent-launch.ts
+++ b/packages/cli/src/utils/agent-launch.ts
@@ -1,0 +1,185 @@
+import * as clack from '@clack/prompts';
+import {
+    viwo,
+    ConfigManager,
+    GitHubManager,
+    GitLabManager,
+    ProjectConfigManager,
+} from '@viwo/core';
+
+export interface PrepareAgentLaunchOptions {
+    prompt?: string;
+    promptFile?: string;
+}
+
+const readPromptFile = async (promptFile: string): Promise<string> => {
+    const file = Bun.file(promptFile);
+    if (!(await file.exists())) {
+        throw new Error(`Failed to read prompt file: ${promptFile}`);
+    }
+
+    const content = (await file.text()).trim();
+    if (!content) {
+        throw new Error('Prompt file is empty');
+    }
+
+    return content;
+};
+
+export const preparePromptForLaunch = async (
+    options: PrepareAgentLaunchOptions
+): Promise<string> => {
+    let prompt: string;
+
+    if (options.prompt) {
+        prompt = options.prompt;
+    } else if (options.promptFile) {
+        prompt = await readPromptFile(options.promptFile);
+    } else {
+        const { multilineInput } = await import('./multiline-input');
+        prompt = await multilineInput({
+            message: 'Enter your prompt for the AI agent:',
+        });
+    }
+
+    if (!ConfigManager.isAuthConfigured()) {
+        throw new Error(
+            'Authentication is not configured. Run "viwo auth" to set up authentication.'
+        );
+    }
+
+    const issueUrls = GitHubManager.parseIssueUrls(prompt);
+    if (issueUrls.length > 0 && !ConfigManager.hasGitHubToken()) {
+        clack.log.info(
+            `Detected ${issueUrls.length} GitHub issue URL(s). A GitHub token is needed to fetch issue context.`
+        );
+
+        const setupChoice = await clack.select({
+            message: 'Set up GitHub token now?',
+            options: [
+                { label: 'Auto-detect (gh CLI / env var)', value: 'auto' },
+                { label: 'Enter token manually', value: 'manual' },
+                { label: 'Skip — continue without issue context', value: 'skip' },
+            ],
+        });
+
+        if (clack.isCancel(setupChoice)) {
+            throw new Error('Operation cancelled.');
+        }
+
+        if (setupChoice === 'auto') {
+            let resolved = await GitHubManager.resolveGitHubTokenFromGhCli();
+            if (!resolved) resolved = GitHubManager.resolveGitHubTokenFromEnv();
+
+            if (resolved) {
+                ConfigManager.setGitHubToken(resolved);
+                clack.log.success('GitHub token saved.');
+            } else {
+                clack.log.warn(
+                    'No token found. Install gh CLI (gh auth login) or set GITHUB_TOKEN env var.'
+                );
+            }
+        } else if (setupChoice === 'manual') {
+            const tokenInput = await clack.password({
+                message: 'Enter your GitHub personal access token:',
+            });
+
+            if (clack.isCancel(tokenInput)) {
+                throw new Error('Operation cancelled.');
+            }
+
+            if (tokenInput && tokenInput.trim()) {
+                ConfigManager.setGitHubToken(tokenInput.trim());
+                clack.log.success('GitHub token saved.');
+            }
+        }
+    }
+
+    const gitlabUrls = GitLabManager.parseGitLabResourceUrls(prompt);
+    if (gitlabUrls.length > 0 && !ConfigManager.hasGitLabToken()) {
+        clack.log.info(
+            `Detected ${gitlabUrls.length} GitLab issue/MR URL(s). A GitLab token is needed to fetch context.`
+        );
+
+        const setupChoice = await clack.select({
+            message: 'Set up GitLab token now?',
+            options: [
+                { label: 'Auto-detect (glab CLI / env var)', value: 'auto' },
+                { label: 'Enter token manually', value: 'manual' },
+                { label: 'Skip — continue without GitLab context', value: 'skip' },
+            ],
+        });
+
+        if (clack.isCancel(setupChoice)) {
+            throw new Error('Operation cancelled.');
+        }
+
+        if (setupChoice === 'auto') {
+            let resolved = await GitLabManager.resolveGitLabTokenFromGlabCli();
+            if (!resolved) resolved = GitLabManager.resolveGitLabTokenFromEnv();
+
+            if (resolved) {
+                ConfigManager.setGitLabToken(resolved);
+                clack.log.success('GitLab token saved.');
+            } else {
+                clack.log.warn(
+                    'No token found. Install glab CLI (glab auth login) or set GITLAB_TOKEN env var.'
+                );
+            }
+        } else if (setupChoice === 'manual') {
+            const tokenInput = await clack.password({
+                message: 'Enter your GitLab personal access token:',
+            });
+
+            if (clack.isCancel(tokenInput)) {
+                throw new Error('Operation cancelled.');
+            }
+
+            if (tokenInput && tokenInput.trim()) {
+                ConfigManager.setGitLabToken(tokenInput.trim());
+                clack.log.success('GitLab token saved.');
+            }
+        }
+    }
+
+    let expandedPrompt = prompt;
+    expandedPrompt = await GitHubManager.expandPromptWithIssues(expandedPrompt);
+    expandedPrompt = await GitLabManager.expandPromptWithGitLabResources(expandedPrompt);
+
+    return expandedPrompt;
+};
+
+const normalizeAgentType = (agent?: string): 'claude-code' | 'cline' | 'cursor' => {
+    if (agent === 'cline' || agent === 'cursor') {
+        return agent;
+    }
+
+    return 'claude-code';
+};
+
+export const launchAgentForSession = async (options: {
+    sessionId: string;
+    worktreePath: string;
+    repoPath: string;
+    prompt?: string;
+    promptFile?: string;
+    agent?: string;
+}): Promise<void> => {
+    const expandedPrompt = await preparePromptForLaunch({
+        prompt: options.prompt,
+        promptFile: options.promptFile,
+    });
+
+    const projectConfig = ProjectConfigManager.loadProjectConfig({
+        repoPath: options.repoPath,
+    }) as { preAgent?: string[] } | null;
+
+    await (viwo.startContainer as any)({
+        sessionId: parseInt(options.sessionId, 10),
+        worktreePath: options.worktreePath,
+        prompt: expandedPrompt,
+        agent: normalizeAgentType(options.agent),
+        model: ConfigManager.getPreferredModel() ?? 'sonnet',
+        preAgentCommands: projectConfig?.preAgent,
+    });
+};


### PR DESCRIPTION
## Summary
- add `viwo create` for workspace-only creation
- refactor prompt/auth/issue expansion into shared agent launch logic
- let `viwo list` start an agent when no container exists while keeping attach for existing containers
- clarify workspace/container/agent wording in CLI output and docs

## Testing
- bun run typecheck
- cd packages/cli && bun test src/utils/__tests__/formatters.test.ts
- bun packages/cli/src/cli.ts create --help
- bun packages/cli/src/cli.ts attach --help
