### PR TITLE
feat: replace tmux with dtach for agent sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,7 +332,7 @@ Commands in `packages/cli/src/commands/`:
 - `attach` - Attach to a running Claude Code session via dtach
     - With no args, shows interactive list of running sessions to choose from
     - With `<session-id>`, attaches directly to the specified session
-    - Runs `docker exec -it viwo-{identifier} dtach -a /tmp/viwo-state/viwo.sock -r winch`
+    - Runs `docker exec -it viwo-{identifier} dtach -a /tmp/viwo.sock -r winch`
     - Prints detach hint (Ctrl+\\) before attaching
     - Errors if container doesn't exist or isn't running
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,11 +329,11 @@ Commands in `packages/cli/src/commands/`:
     - Manual token entry
     - Configure/reset self-hosted GitLab instance URL
     - View status and remove stored token
-- `attach` - Attach to a running Claude Code session via tmux
+- `attach` - Attach to a running Claude Code session via dtach
     - With no args, shows interactive list of running sessions to choose from
     - With `<session-id>`, attaches directly to the specified session
-    - Runs `docker exec -it viwo-{identifier} tmux attach -t viwo`
-    - Prints detach hint (Ctrl+B, D) before attaching
+    - Runs `docker exec -it viwo-{identifier} dtach -a /tmp/viwo-state/viwo.sock -r winch`
+    - Prints detach hint (Ctrl+\\) before attaching
     - Errors if container doesn't exist or isn't running
 
 ### Preflight Checks & Version Checking
@@ -472,7 +472,7 @@ After making changes to the codebase, verify the full session lifecycle using th
 5. **Verify the Claude Code session received the prompt** inside the container:
 
     ```bash
-    docker exec <container-name> tmux capture-pane -t viwo -p
+    docker logs <container-name>
     ```
 
     Confirm the prompt text appears and Claude Code has responded.
@@ -489,7 +489,7 @@ After making changes to the codebase, verify the full session lifecycle using th
 ### Key Points
 
 - Always use `bun packages/cli/src/cli.ts` (not the globally installed `viwo`) to test development changes.
-- Verify each layer independently: CLI output, Docker state (`docker ps`), and in-container state (`tmux capture-pane`). Don't assume one layer is correct because another looks fine.
+- Verify each layer independently: CLI output, Docker state (`docker ps`), and container output/state (`docker logs`, `/tmp/viwo-state/viwo-state.json`). Don't assume one layer is correct because another looks fine.
 - The `--repo`, `--branch`, and `--prompt` flags are all required for fully non-interactive `start`.
 
 ## Known Limitations

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Today, the primary runtime is **Claude Code** inside Docker, with VIWO handling 
 - **Project-aware setup**: Configure host-side setup, in-container setup, and custom bind mounts with `viwo.yml`.
 - **Better auth support**: Use either an Anthropic API key or Claude subscription OAuth credentials.
 - **Issue-driven workflows**: Expand GitHub issues and GitLab issues/MRs directly into the prompt.
-- **Attach anytime**: Reconnect to a running session through `tmux` in the container.
+- **Attach anytime**: Reconnect to a running session through `dtach` in the container.
 - **Session visibility**: Sync Docker state, inspect running/completed sessions, and capture container output.
 
 ## Table of Contents

--- a/bun.lock
+++ b/bun.lock
@@ -20,11 +20,12 @@
     },
     "packages/cli": {
       "name": "@viwo/cli",
-      "version": "0.6.0",
+      "version": "0.10.1",
       "bin": {
         "viwo": "./dist/cli.js",
       },
       "dependencies": {
+        "@clack/core": "^0.5.0",
         "@clack/prompts": "^0.11.0",
         "@inquirer/prompts": "^8.0.1",
         "@viwo/core": "workspace:*",
@@ -41,7 +42,7 @@
     },
     "packages/core": {
       "name": "@viwo/core",
-      "version": "0.6.0",
+      "version": "0.10.1",
       "dependencies": {
         "dockerode": "^4.0.2",
         "drizzle-orm": "^0.44.7",

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     gnupg \
-    tmux \
+    dtach \
     locales \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \

--- a/packages/agents/claude-code/claude-bootstrap.sh
+++ b/packages/agents/claude-code/claude-bootstrap.sh
@@ -135,19 +135,18 @@ elif [ -n "${VIWO_PROMPT:-}" ]; then
   unset VIWO_PROMPT
 fi
 
-# --- Launch Claude Code inside tmux ---
+# --- Launch Claude Code under dtach ---
 
 EXIT_CODE_FILE="/tmp/viwo-state/claude-exit-code"
+VIWO_SOCKET="/tmp/viwo-state/viwo.sock"
 
-# Enable mouse scrolling in tmux so users can scroll through output
-echo "set -g mouse on" >> ~/.tmux.conf
-
-# Launch Claude Code inside tmux, drop to bash when it exits
-# This keeps the tmux session alive so users can always attach
-tmux new-session -d -s viwo \
-  "$CLAUDE_CMD; echo \$? > $EXIT_CODE_FILE; printf '{\"status\":\"exited\",\"timestamp\":\"%s\",\"exitCode\":%s}' \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$(cat $EXIT_CODE_FILE)\" > $STATE_FILE; exec bash"
-
-# Keep container alive as long as tmux session exists
-while tmux has-session -t viwo 2>/dev/null; do
-  sleep 2
-done
+# dtach -N creates a new session, runs the child in a PTY, and stays in the
+# foreground as PID 1. When the inner bash exits, dtach exits and the
+# container stops.
+exec dtach -N "$VIWO_SOCKET" -r winch bash -c "
+  $CLAUDE_CMD
+  echo \$? > $EXIT_CODE_FILE
+  printf '{\"status\":\"exited\",\"timestamp\":\"%s\",\"exitCode\":%s}' \\
+    \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \"\$(cat $EXIT_CODE_FILE)\" > $STATE_FILE
+  exec bash
+"

--- a/packages/agents/claude-code/claude-bootstrap.sh
+++ b/packages/agents/claude-code/claude-bootstrap.sh
@@ -138,7 +138,10 @@ fi
 # --- Launch Claude Code under dtach ---
 
 EXIT_CODE_FILE="/tmp/viwo-state/claude-exit-code"
-VIWO_SOCKET="/tmp/viwo-state/viwo.sock"
+# Socket lives outside the host bind mount: macOS Docker bind mounts (virtiofs)
+# don't support unix sockets, and keeping it container-only avoids leaking the
+# socket file onto the host where another host process could attach to it.
+VIWO_SOCKET="/tmp/viwo.sock"
 
 # dtach -N creates a new session, runs the child in a PTY, and stays in the
 # foreground as PID 1. When the inner bash exits, dtach exits and the

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viwo/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "description": "CLI for VIWO - git worktree + containerization + agent harness",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -7,7 +7,7 @@ import { preflightChecksOrExit } from '../utils/prerequisites';
 import { execSync } from 'child_process';
 
 export const attachCommand = new Command('attach')
-    .description('Attach to a running workspace container via tmux')
+    .description('Attach to a running workspace container via dtach')
     .argument('[workspace-id]', 'Workspace ID to attach to')
     .action(async (sessionId?: string) => {
         try {
@@ -88,7 +88,7 @@ export const attachCommand = new Command('attach')
             if (!containerInfo.running) {
                 console.log(chalk.dim(`Container ${containerName} is stopped. Restarting...`));
                 await DockerManager.startContainer({ containerId: containerName });
-                // Wait briefly for tmux to initialize
+                // Wait briefly for dtach to initialize
                 await new Promise((r) => setTimeout(r, 1000));
                 console.log(chalk.green('Container restarted.'));
             }
@@ -96,10 +96,10 @@ export const attachCommand = new Command('attach')
             // Print attach hint and run docker exec
             console.log();
             console.log(chalk.dim(`Attaching to workspace ${targetSessionId} (${containerName})...`));
-            console.log(chalk.yellow('Detach with: Ctrl+B, D'));
+            console.log(chalk.yellow('Detach with: Ctrl+\\'));
             console.log();
 
-            execSync(`docker exec -it ${containerName} tmux attach -t viwo`, {
+            execSync(`docker exec -it ${containerName} dtach -a /tmp/viwo-state/viwo.sock -r winch`, {
                 stdio: 'inherit',
             });
         } catch (error) {

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -99,7 +99,7 @@ export const attachCommand = new Command('attach')
             console.log(chalk.yellow('Detach with: Ctrl+\\'));
             console.log();
 
-            execSync(`docker exec -it ${containerName} dtach -a /tmp/viwo-state/viwo.sock -r winch`, {
+            execSync(`docker exec -it ${containerName} dtach -a /tmp/viwo.sock -r winch`, {
                 stdio: 'inherit',
             });
         } catch (error) {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -51,7 +51,7 @@ const runPostCreateActions = async (workspace: WorktreeSession): Promise<void> =
                     console.log(chalk.dim('Container is running in the background.'));
                     console.log();
                     console.log(`  Attach:  ${chalk.cyan(`viwo attach ${updated.id}`)}`);
-                    console.log(`  Detach:  ${chalk.dim('Ctrl+B, D (inside tmux)')}`);
+                    console.log(`  Detach:  ${chalk.dim('Ctrl+\\ (inside dtach)')}`);
                     console.log();
                 }
                 return;

--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -218,7 +218,7 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
             console.log(chalk.dim(`Attaching to workspace ${session.id} (${containerName})...`));
             console.log(chalk.yellow('Detach with: Ctrl+\\'));
             console.log();
-            execSync(`docker exec -it ${containerName} dtach -a /tmp/viwo-state/viwo.sock -r winch`, {
+            execSync(`docker exec -it ${containerName} dtach -a /tmp/viwo.sock -r winch`, {
                 stdio: 'inherit',
             });
             return 'back';

--- a/packages/cli/src/commands/list-interactive.ts
+++ b/packages/cli/src/commands/list-interactive.ts
@@ -216,9 +216,9 @@ const handleSessionAction = async (session: WorktreeSession): Promise<'back' | '
 
             console.log();
             console.log(chalk.dim(`Attaching to workspace ${session.id} (${containerName})...`));
-            console.log(chalk.yellow('Detach with: Ctrl+B, D'));
+            console.log(chalk.yellow('Detach with: Ctrl+\\'));
             console.log();
-            execSync(`docker exec -it ${containerName} tmux attach -t viwo`, {
+            execSync(`docker exec -it ${containerName} dtach -a /tmp/viwo-state/viwo.sock -r winch`, {
                 stdio: 'inherit',
             });
             return 'back';

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -135,7 +135,7 @@ export const startCommand = new Command('start')
             console.log(chalk.dim('Container is running in the background.'));
             console.log();
             console.log(`  Attach:  ${chalk.cyan(`viwo attach ${workspace.id}`)}`);
-            console.log(`  Detach:  ${chalk.dim('Ctrl+B, D (inside tmux)')}`);
+            console.log(`  Detach:  ${chalk.dim('Ctrl+\\ (inside dtach)')}`);
             console.log();
             clack.outro('Workspace ready!');
             process.exit(0);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viwo/core",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Core SDK for VIWO - git worktree + containerization + agent harness",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core/src/managers/docker-manager.ts
+++ b/packages/core/src/managers/docker-manager.ts
@@ -39,7 +39,7 @@ const getDockerConfig = (): Docker.DockerOptions => {
 const dockerSdk = new Docker(getDockerConfig());
 
 // Default Claude Code image name
-export const CLAUDE_CODE_IMAGE = 'overseedai/viwo-claude-code:0.10.0';
+export const CLAUDE_CODE_IMAGE = 'overseedai/viwo-claude-code:0.10.1';
 
 // Claude Code CLI version installed in the image
 export const CLAUDE_CODE_VERSION = '2.1.96';
@@ -509,7 +509,7 @@ export const syncDockerState = async (): Promise<SyncDockerStateResult> => {
             }
 
             // Determine new session status based on container + agent state
-            // Container exit code reflects bash (tmux fallthrough), not Claude itself.
+            // Container exit code reflects bash (dtach fallthrough), not Claude itself.
             // The agent's actual exit code is in viwo-state.json.
             let newStatus: SessionStatus | null = null;
             let reason = '';

--- a/tasks/prd-interactive-containers.md
+++ b/tasks/prd-interactive-containers.md
@@ -1,5 +1,7 @@
 # PRD: Long-Running Interactive Claude Code Containers
 
+> Note: the original tmux-based design described below was later replaced by dtach to restore native link click-through and host-terminal scroll behavior.
+
 ## Introduction
 
 VIWO currently runs ephemeral Claude Code sessions in headless mode inside Docker containers. This architecture rehaul replaces that with long-running containers running Claude Code in regular interactive mode via tmux. Users can attach to live sessions, provide follow-up prompts, detach, and monitor session state — all without losing context.


### PR DESCRIPTION
## Summary
- replace tmux with dtach for interactive Claude Code sessions
- restore native link click-through and host terminal scroll behavior
- update CLI attach flows, detach hints, docs, and image/version sync

## Changes
- install `dtach` instead of `tmux` in `packages/agents/claude-code/Dockerfile`
- run Claude Code under `dtach` in `packages/agents/claude-code/claude-bootstrap.sh`
- update attach commands to use `dtach -a /tmp/viwo-state/viwo.sock -r winch`
- update detach hints from `Ctrl+B, D` to `Ctrl+\\`
- refresh related docs/comments in `CLAUDE.md`, `README.md`, and the interactive containers PRD
- bump `@viwo/core`, `@viwo/cli`, and `CLAUDE_CODE_IMAGE` to `0.10.1`

## Validation
- `bun run typecheck`
- `bun run build`
- `docker build -t viwo-claude-code-test packages/agents/claude-code`

Closes #143
Closes #136
