### PR TITLE
feat: extend the viwo base image via project Dockerfile (#55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,10 @@ VIWO automatically detects and loads project-specific configuration from the rep
         - Commands run after credentials and git are configured but before Claude launches
         - If any command fails, the container exits before Claude starts
         - Example use cases: installing dependencies (`npm install`, `bun install`), building (`npm run build`), or any other setup Claude needs available during its work
+    - `dockerfile`: Path (relative to repo root, or absolute) to a project Dockerfile that extends the viwo base image
+        - Must start with `FROM overseedai/viwo-claude-code:<version>` matching the viwo CLI's pinned base image — guarantees the bootstrap script, dtach, the `claude` user, and env contracts are preserved
+        - Built once per content hash and tagged `viwo-derived:<hash>`; subsequent sessions reuse the cached image
+        - Use this to add language runtimes, system packages, or any tooling viwo's base image doesn't ship — see `image-builder.ts`
 
 **Example configuration**:
 
@@ -173,6 +177,18 @@ binds:
     - source: ~/models
       target: /models
       readonly: true
+
+dockerfile: ./viwo.Dockerfile
+```
+
+**Example `viwo.Dockerfile`**:
+
+```dockerfile
+FROM overseedai/viwo-claude-code:0.10.1
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends unzip jq
+USER claude
+RUN curl -fsSL https://bun.sh/install | bash
 ```
 
 **Implementation**:
@@ -181,6 +197,7 @@ binds:
 - `loadProjectConfig()` reads and validates configuration file
 - `hasProjectConfig()` checks if configuration file exists
 - Post-install hooks execute in `viwo.start()` flow after worktree creation
+- `image-builder.ts` validates the user's Dockerfile FROM line, hashes its contents, and builds (or reuses) `viwo-derived:<hash>` before container creation
 
 ### Worktrees Storage Configuration
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * as IDEManager from './managers/ide-manager';
 export * as GitHubManager from './managers/github-manager';
 export * as GitLabManager from './managers/gitlab-manager';
 export * as ProjectConfigManager from './managers/project-config-manager';
+export * as ImageBuilder from './managers/image-builder';
 
 // Export repository management
 export {

--- a/packages/core/src/managers/__tests__/image-builder.test.ts
+++ b/packages/core/src/managers/__tests__/image-builder.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { assertExtendsBaseImage, buildDerivedImage } from '../image-builder';
+import { CLAUDE_CODE_IMAGE } from '../docker-manager';
+
+describe('image-builder validation', () => {
+    let testDir: string;
+
+    beforeEach(() => {
+        testDir = join(tmpdir(), `viwo-image-test-${Date.now()}-${Math.random()}`);
+        mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(testDir, { recursive: true, force: true });
+    });
+
+    test('rejects missing Dockerfile', async () => {
+        await expect(
+            buildDerivedImage({ dockerfilePath: 'missing.Dockerfile', repoPath: testDir })
+        ).rejects.toThrow(/Dockerfile not found/);
+    });
+
+    test('rejects Dockerfile with wrong base image', async () => {
+        const path = join(testDir, 'viwo.Dockerfile');
+        writeFileSync(path, 'FROM ubuntu:24.04\nRUN echo hi\n');
+        await expect(
+            buildDerivedImage({ dockerfilePath: path, repoPath: testDir })
+        ).rejects.toThrow(/must extend the viwo base image/);
+    });
+
+    test('rejects Dockerfile that does not start with FROM', async () => {
+        const path = join(testDir, 'viwo.Dockerfile');
+        writeFileSync(path, 'RUN echo hi\n');
+        await expect(
+            buildDerivedImage({ dockerfilePath: path, repoPath: testDir })
+        ).rejects.toThrow(/first non-comment line must be a FROM/);
+    });
+
+    test('skips comments and blank lines when locating the FROM directive', () => {
+        const contents = `# leading comment\n\n# another\nFROM ${CLAUDE_CODE_IMAGE}\nRUN echo hi\n`;
+        expect(() =>
+            assertExtendsBaseImage({ contents, dockerfilePath: 'fake' })
+        ).not.toThrow();
+    });
+
+    test('rejects multi-stage builds whose first FROM is not the viwo base', () => {
+        const contents = `FROM node:22 AS builder\nFROM ${CLAUDE_CODE_IMAGE}\n`;
+        expect(() =>
+            assertExtendsBaseImage({ contents, dockerfilePath: 'fake' })
+        ).toThrow(/must extend the viwo base image/);
+    });
+});

--- a/packages/core/src/managers/agent-manager.ts
+++ b/packages/core/src/managers/agent-manager.ts
@@ -24,6 +24,7 @@ export interface InitializeAgentOptions {
     config: AgentConfig;
     preAgentCommands?: string[];
     customBinds?: string[];
+    image?: string;
 }
 
 export interface InitializeAgentResult {
@@ -124,12 +125,17 @@ const startClaudeContainer = async (options: {
     env: Record<string, string>;
     preAgentCommands?: string[];
     customBinds?: string[];
+    image?: string;
 }): Promise<InitializeAgentResult> => {
     const { sessionId, worktreePath, config, env, preAgentCommands, customBinds } = options;
+    const image = options.image ?? CLAUDE_CODE_IMAGE;
 
-    const imageExists = await checkImageExists({ image: CLAUDE_CODE_IMAGE });
-    if (!imageExists) {
-        await pullImage({ image: CLAUDE_CODE_IMAGE });
+    // Custom (derived) images are built locally and never pulled.
+    if (image === CLAUDE_CODE_IMAGE) {
+        const imageExists = await checkImageExists({ image });
+        if (!imageExists) {
+            await pullImage({ image });
+        }
     }
 
     const containerName = generateContainerName(sessionId);
@@ -143,7 +149,7 @@ const startClaudeContainer = async (options: {
 
     const containerInfo = await createContainer({
         name: containerName,
-        image: CLAUDE_CODE_IMAGE,
+        image,
         worktreePath,
         env: { ...env, ...claudeEnv },
         tty: true,
@@ -170,7 +176,7 @@ const startClaudeContainer = async (options: {
         updates: {
             containerId: containerInfo.id,
             containerName: containerInfo.name,
-            containerImage: CLAUDE_CODE_IMAGE,
+            containerImage: image,
             claudeCodeVersion: CLAUDE_CODE_VERSION,
             status: SessionStatus.RUNNING,
             lastActivity: new Date().toISOString(),
@@ -237,6 +243,7 @@ const initializeClaudeCodeWithApiKey = async (
         env: { ANTHROPIC_API_KEY: apiKey },
         preAgentCommands: options.preAgentCommands,
         customBinds: options.customBinds,
+        image: options.image,
     });
 };
 
@@ -281,6 +288,7 @@ const initializeClaudeCodeWithOAuth = async (
         },
         preAgentCommands: options.preAgentCommands,
         customBinds: options.customBinds,
+        image: options.image,
     });
 };
 

--- a/packages/core/src/managers/docker-manager.ts
+++ b/packages/core/src/managers/docker-manager.ts
@@ -83,14 +83,18 @@ export interface BuildImageOptions {
 
 export const buildImage = async (options: BuildImageOptions): Promise<void> => {
     const contextPath = options.context || path.dirname(options.dockerfilePath);
+    const dockerfileRelative = path.relative(contextPath, options.dockerfilePath);
 
     return new Promise((resolve, reject) => {
         dockerSdk.buildImage(
             {
                 context: contextPath,
-                src: [path.basename(options.dockerfilePath)],
+                // Include just the Dockerfile in the tar context. Dockerode
+                // sends only what's listed in `src`; for full project context
+                // (COPY of repo files), callers can extend this later.
+                src: [dockerfileRelative],
             },
-            { t: options.imageName },
+            { t: options.imageName, dockerfile: dockerfileRelative },
             (err, stream) => {
                 if (err) {
                     reject(err);

--- a/packages/core/src/managers/image-builder.ts
+++ b/packages/core/src/managers/image-builder.ts
@@ -1,0 +1,103 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+import { buildImage, checkImageExists, CLAUDE_CODE_IMAGE } from './docker-manager';
+
+const DERIVED_IMAGE_PREFIX = 'viwo-derived';
+
+export interface BuildDerivedImageOptions {
+    dockerfilePath: string;
+    repoPath: string;
+}
+
+export interface BuildDerivedImageResult {
+    imageName: string;
+    rebuilt: boolean;
+}
+
+/**
+ * Builds a project-specific image that extends the viwo base image.
+ *
+ * Validates the Dockerfile's first FROM line matches CLAUDE_CODE_IMAGE so the
+ * bootstrap script, dtach, and the `claude` user contracts still hold. Tags
+ * the result by content hash so unchanged Dockerfiles reuse the cached image.
+ */
+export const buildDerivedImage = async (
+    options: BuildDerivedImageOptions
+): Promise<BuildDerivedImageResult> => {
+    const { dockerfilePath, repoPath } = options;
+
+    const absoluteDockerfile = isAbsolute(dockerfilePath)
+        ? dockerfilePath
+        : resolve(repoPath, dockerfilePath);
+
+    if (!existsSync(absoluteDockerfile)) {
+        throw new Error(`Dockerfile not found: ${absoluteDockerfile}`);
+    }
+
+    const contents = readFileSync(absoluteDockerfile, 'utf-8');
+
+    assertExtendsBaseImage({ contents, dockerfilePath: absoluteDockerfile });
+
+    // Hash the Dockerfile + the base image tag so a base-image upgrade also
+    // triggers a rebuild even if the Dockerfile bytes are identical.
+    const hash = createHash('sha256')
+        .update(contents)
+        .update('\0')
+        .update(CLAUDE_CODE_IMAGE)
+        .digest('hex')
+        .slice(0, 12);
+
+    const imageName = `${DERIVED_IMAGE_PREFIX}:${hash}`;
+
+    if (await checkImageExists({ image: imageName })) {
+        return { imageName, rebuilt: false };
+    }
+
+    await buildImage({
+        dockerfilePath: absoluteDockerfile,
+        imageName,
+        context: repoPath,
+    });
+
+    return { imageName, rebuilt: true };
+};
+
+export interface AssertExtendsBaseImageOptions {
+    contents: string;
+    dockerfilePath: string;
+}
+
+/**
+ * Throws if the Dockerfile's first non-comment line isn't `FROM <viwo base>`.
+ * Exported for unit testing without needing a Docker daemon.
+ */
+export const assertExtendsBaseImage = (options: AssertExtendsBaseImageOptions): void => {
+    const { contents, dockerfilePath } = options;
+
+    const firstFrom = contents
+        .split('\n')
+        .map((line) => line.trim())
+        .find((line) => line.length > 0 && !line.startsWith('#'));
+
+    if (!firstFrom || !/^FROM\s+/i.test(firstFrom)) {
+        throw new Error(
+            `${dockerfilePath}: first non-comment line must be a FROM ${CLAUDE_CODE_IMAGE} directive`
+        );
+    }
+
+    const match = firstFrom.match(/^FROM\s+(\S+)/i);
+    const fromImage = match?.[1];
+
+    if (fromImage !== CLAUDE_CODE_IMAGE) {
+        throw new Error(
+            `${dockerfilePath}: must extend the viwo base image. Expected "FROM ${CLAUDE_CODE_IMAGE}" but found "FROM ${fromImage}". ` +
+                `Pin the exact base tag so the bootstrap script and runtime contracts are guaranteed.`
+        );
+    }
+};
+
+export const imageBuilder = {
+    buildDerivedImage,
+    assertExtendsBaseImage,
+};

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -104,6 +104,7 @@ export const StartContainerOptionsSchema = z.object({
     model: z.string().optional(),
     preAgentCommands: z.array(z.string()).optional(),
     customBinds: z.array(z.string()).optional(),
+    image: z.string().optional(),
 });
 export type StartContainerOptions = z.infer<typeof StartContainerOptionsSchema>;
 
@@ -181,6 +182,7 @@ export const ProjectConfigSchema = z.object({
     postInstall: z.array(z.string()).optional(),
     preAgent: z.array(z.string()).optional(),
     binds: z.array(CustomBindSchema).optional(),
+    dockerfile: z.string().min(1).optional(),
 });
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
 

--- a/packages/core/src/viwo.ts
+++ b/packages/core/src/viwo.ts
@@ -38,6 +38,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { sessionToWorktreeSession } from './utils/types';
 import { loadProjectConfig, resolveCustomBinds } from './managers/project-config-manager';
+import { buildDerivedImage } from './managers/image-builder';
 import { getPreferredModel } from './managers/config-manager';
 import { expandPromptWithIssues } from './managers/github-manager';
 import { expandPromptWithGitLabResources } from './managers/gitlab-manager';
@@ -182,6 +183,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
             },
             preAgentCommands: validated.preAgentCommands,
             customBinds: validated.customBinds,
+            image: validated.image,
         });
 
         return {
@@ -247,6 +249,15 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                           })
                         : undefined;
 
+                let derivedImage: string | undefined;
+                if (projectConfig?.dockerfile) {
+                    const built = await buildDerivedImage({
+                        dockerfilePath: projectConfig.dockerfile,
+                        repoPath: worktreeResult.repoPath,
+                    });
+                    derivedImage = built.imageName;
+                }
+
                 // Phase 2: Start container
                 const containerResult = await startContainerPhase({
                     sessionId: worktreeResult.sessionId,
@@ -256,6 +267,7 @@ export function createViwo(config?: Partial<ViwoConfig>): Viwo {
                     model: getPreferredModel() ?? 'sonnet',
                     preAgentCommands: projectConfig?.preAgent,
                     customBinds,
+                    image: derivedImage,
                 });
 
                 worktreeSession.containerName = containerResult.containerName;


### PR DESCRIPTION
## Summary
- Adds a `dockerfile` field to `viwo.yml` that points at a project Dockerfile extending the viwo base image.
- Validates the Dockerfile's first FROM line matches the pinned base tag so bootstrap/dtach/`claude` user contracts are preserved.
- Caches derived images by content hash (`viwo-derived:<hash>`) so subsequent sessions skip the rebuild.
- Skips the registry pull for locally-built derived images.
- Closes #55.

## Why this shape
We want the base image to stay **opinionated about viwo, not opinionated about user stacks**. Extension lets users add anything they need (Bun, Python, jq, system packages) in their own repo without us shipping a kitchen-sink image or chasing per-user requests.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test` — 129 pass, 0 fail (5 new tests for `assertExtendsBaseImage`)
- [x] End-to-end: created a `viwo.Dockerfile` adding `unzip` + `jq`, ran `viwo start`, confirmed:
  - container runs on `viwo-derived:<hash>` (not the base tag)
  - `unzip` and `jq` are installed inside
  - second `viwo start` reuses the cached derived image (~sub-second)
- [ ] Reviewer: try a Dockerfile with the wrong FROM and confirm the error message is clear