### PR TITLE
security: store encryption key in OS keychain (#154)

### DIFF
--- a/packages/core/src/managers/__tests__/key-store.test.ts
+++ b/packages/core/src/managers/__tests__/key-store.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { getEncryptionKey, getLegacyEncryptionKey, __resetKeyCacheForTests } from '../key-store';
+
+describe('key-store', () => {
+    test('getEncryptionKey returns a 32-byte buffer', () => {
+        __resetKeyCacheForTests();
+        const key = getEncryptionKey();
+        expect(Buffer.isBuffer(key)).toBe(true);
+        expect(key.length).toBe(32);
+    });
+
+    test('getEncryptionKey is stable across calls within a process', () => {
+        __resetKeyCacheForTests();
+        const a = getEncryptionKey();
+        const b = getEncryptionKey();
+        expect(a.equals(b)).toBe(true);
+    });
+
+    test('getLegacyEncryptionKey is deterministic from hostname + username', () => {
+        const a = getLegacyEncryptionKey();
+        const b = getLegacyEncryptionKey();
+        expect(a.equals(b)).toBe(true);
+        expect(a.length).toBe(32);
+    });
+
+    test('keys produced by the new and legacy schemes differ', () => {
+        __resetKeyCacheForTests();
+        const newKey = getEncryptionKey();
+        const legacyKey = getLegacyEncryptionKey();
+        expect(newKey.equals(legacyKey)).toBe(false);
+    });
+
+    test('AES-GCM round trip with the new key works', () => {
+        __resetKeyCacheForTests();
+        const key = getEncryptionKey();
+        const iv = randomBytes(16);
+        const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: 16 });
+        const encrypted = Buffer.concat([cipher.update('hello', 'utf-8'), cipher.final()]);
+        const tag = cipher.getAuthTag();
+
+        const decipher = createDecipheriv('aes-256-gcm', key, iv, { authTagLength: 16 });
+        decipher.setAuthTag(tag);
+        const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString(
+            'utf-8'
+        );
+        expect(decrypted).toBe('hello');
+    });
+});

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -1,25 +1,17 @@
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'crypto';
-import { hostname, userInfo } from 'os';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import { db } from '../db';
 import { configurations } from '../db-schemas';
 import { eq } from 'drizzle-orm';
 import type { AuthMethod, IDEType, ModelType } from '../types.js';
 import { expandTilde } from '../utils/paths.js';
+import { getEncryptionKey, getLegacyEncryptionKey } from './key-store';
 
 const ALGORITHM = 'aes-256-gcm';
-const KEY_LENGTH = 32;
 const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
-const SALT = 'viwo-config-salt';
-
-// Derive encryption key from machine-specific data
-const deriveKey = (): Buffer => {
-    const machineId = `${hostname()}-${userInfo().username}`;
-    return scryptSync(machineId, SALT, KEY_LENGTH);
-};
 
 const encrypt = (plaintext: string): string => {
-    const key = deriveKey();
+    const key = getEncryptionKey();
     const iv = randomBytes(IV_LENGTH);
     const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
 
@@ -32,8 +24,7 @@ const encrypt = (plaintext: string): string => {
     return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
 };
 
-const decrypt = (encryptedData: string): string => {
-    const key = deriveKey();
+const decryptWithKey = (encryptedData: string, key: Buffer): string => {
     const parts = encryptedData.split(':');
 
     if (parts.length !== 3) {
@@ -52,6 +43,44 @@ const decrypt = (encryptedData: string): string => {
     decrypted += decipher.final('utf8');
 
     return decrypted;
+};
+
+/**
+ * Decrypt a stored ciphertext, transparently migrating from the legacy
+ * hostname-derived key (issue #154) to the OS-keychain key when needed.
+ *
+ * If the new key fails but the legacy key succeeds, the value is re-encrypted
+ * under the new key via `persistMigrated` so subsequent reads avoid the
+ * fallback path. If both keys fail (e.g. user moved machines and lost the
+ * old hostname), returns null and prints a one-line hint.
+ */
+const decryptWithMigration = (
+    encryptedData: string,
+    label: string,
+    persistMigrated: (newCipher: string) => void
+): string | null => {
+    try {
+        return decryptWithKey(encryptedData, getEncryptionKey());
+    } catch {
+        // fall through to legacy attempt
+    }
+
+    try {
+        const plain = decryptWithKey(encryptedData, getLegacyEncryptionKey());
+        try {
+            persistMigrated(encrypt(plain));
+        } catch {
+            // re-encryption persistence is best-effort; the plaintext is still
+            // returned so the caller can use it for this session.
+        }
+        return plain;
+    } catch {
+        console.warn(
+            `viwo: stored ${label} could not be decrypted. ` +
+                `Re-add it via 'viwo config' to restore access.`
+        );
+        return null;
+    }
 };
 
 export type ApiKeyProvider = 'anthropic';
@@ -114,12 +143,12 @@ export const getApiKey = (options: GetApiKeyOptions): string | null => {
         return null;
     }
 
-    try {
-        return decrypt(encryptedKey);
-    } catch (e) {
-        console.log('Error decrypting API key:', e);
-        return null;
-    }
+    const rowId = config[0]!.id;
+    return decryptWithMigration(encryptedKey, `${provider} API key`, (newCipher) => {
+        const updates: Record<string, string> = { updatedAt: new Date().toISOString() };
+        if (provider === 'anthropic') updates.anthropicApiKey = newCipher;
+        db.update(configurations).set(updates).where(eq(configurations.id, rowId)).run();
+    });
 };
 
 export interface HasApiKeyOptions {
@@ -268,12 +297,13 @@ export const getGitHubToken = (): string | null => {
     const encryptedToken = config[0]!.githubToken;
     if (!encryptedToken) return null;
 
-    try {
-        return decrypt(encryptedToken);
-    } catch (e) {
-        console.log('Error decrypting GitHub token:', e);
-        return null;
-    }
+    const rowId = config[0]!.id;
+    return decryptWithMigration(encryptedToken, 'GitHub token', (newCipher) => {
+        db.update(configurations)
+            .set({ githubToken: newCipher, updatedAt: new Date().toISOString() })
+            .where(eq(configurations.id, rowId))
+            .run();
+    });
 };
 
 export const hasGitHubToken = (): boolean => {
@@ -323,12 +353,13 @@ export const getGitLabToken = (): string | null => {
     const encryptedToken = config[0]!.gitlabToken;
     if (!encryptedToken) return null;
 
-    try {
-        return decrypt(encryptedToken);
-    } catch (e) {
-        console.log('Error decrypting GitLab token:', e);
-        return null;
-    }
+    const rowId = config[0]!.id;
+    return decryptWithMigration(encryptedToken, 'GitLab token', (newCipher) => {
+        db.update(configurations)
+            .set({ gitlabToken: newCipher, updatedAt: new Date().toISOString() })
+            .where(eq(configurations.id, rowId))
+            .run();
+    });
 };
 
 export const hasGitLabToken = (): boolean => {

--- a/packages/core/src/managers/key-store.ts
+++ b/packages/core/src/managers/key-store.ts
@@ -1,0 +1,160 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { hostname, userInfo } from 'node:os';
+import { scryptSync } from 'node:crypto';
+import { joinDataPath } from '../utils/paths';
+
+const KEYCHAIN_SERVICE = 'viwo-encryption-key';
+const KEY_LENGTH = 32;
+const fileFallbackPath = (): string => joinDataPath('.encryption-key');
+
+// Legacy hostname-derived key parameters — kept for migration only.
+// See issue #154; remove the legacy fallback after one or two release cycles.
+const LEGACY_SALT = 'viwo-config-salt';
+
+let cachedKey: Buffer | null = null;
+
+/**
+ * Returns the encryption key, loading it from the OS keychain (macOS) or
+ * libsecret (Linux) when available, falling back to a 0600 keyfile under
+ * the app data dir. Generates a fresh random key on first run.
+ *
+ * Cached for the lifetime of the process so we don't shell out per call.
+ */
+export const getEncryptionKey = (): Buffer => {
+    if (cachedKey) return cachedKey;
+
+    const existing = loadKey();
+    if (existing) {
+        cachedKey = existing;
+        return existing;
+    }
+
+    const fresh = randomBytes(KEY_LENGTH);
+    storeKey(fresh);
+    cachedKey = fresh;
+    return fresh;
+};
+
+/**
+ * Returns the legacy hostname-derived key. Used only by the migration path
+ * in config-manager so existing encrypted DB rows can be re-encrypted under
+ * the new key without forcing the user to re-add every token.
+ */
+export const getLegacyEncryptionKey = (): Buffer => {
+    const machineId = `${hostname()}-${userInfo().username}`;
+    return scryptSync(machineId, LEGACY_SALT, KEY_LENGTH);
+};
+
+const loadKey = (): Buffer | null => {
+    const fromOs = loadFromOsStore();
+    if (fromOs) return fromOs;
+
+    if (existsSync(fileFallbackPath())) {
+        try {
+            const hex = readFileSync(fileFallbackPath(), 'utf-8').trim();
+            const buf = Buffer.from(hex, 'hex');
+            if (buf.length === KEY_LENGTH) return buf;
+        } catch {
+            // fall through to "no key" — caller will generate
+        }
+    }
+    return null;
+};
+
+const storeKey = (key: Buffer): void => {
+    if (storeInOsStore(key)) return;
+
+    // Fall back to file
+    mkdirSync(dirname(fileFallbackPath()), { recursive: true });
+    writeFileSync(fileFallbackPath(), key.toString('hex'), { mode: 0o600 });
+    try {
+        chmodSync(fileFallbackPath(), 0o600);
+    } catch {
+        // best effort on platforms with limited POSIX support
+    }
+};
+
+const loadFromOsStore = (): Buffer | null => {
+    if (process.platform === 'darwin') {
+        try {
+            const out = execFileSync(
+                'security',
+                ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-w'],
+                { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+            ).trim();
+            const buf = Buffer.from(out, 'hex');
+            return buf.length === KEY_LENGTH ? buf : null;
+        } catch {
+            return null;
+        }
+    }
+
+    if (process.platform === 'linux') {
+        try {
+            const out = execFileSync(
+                'secret-tool',
+                ['lookup', 'service', KEYCHAIN_SERVICE],
+                { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+            ).trim();
+            const buf = Buffer.from(out, 'hex');
+            return buf.length === KEY_LENGTH ? buf : null;
+        } catch {
+            return null;
+        }
+    }
+
+    return null;
+};
+
+const storeInOsStore = (key: Buffer): boolean => {
+    const hex = key.toString('hex');
+
+    if (process.platform === 'darwin') {
+        try {
+            execFileSync(
+                'security',
+                [
+                    'add-generic-password',
+                    '-U',
+                    '-s',
+                    KEYCHAIN_SERVICE,
+                    '-a',
+                    userInfo().username,
+                    '-w',
+                    hex,
+                ],
+                { stdio: ['ignore', 'ignore', 'ignore'] }
+            );
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    if (process.platform === 'linux') {
+        try {
+            // secret-tool reads the secret from stdin
+            execFileSync(
+                'secret-tool',
+                ['store', '--label=viwo encryption key', 'service', KEYCHAIN_SERVICE],
+                { input: hex, stdio: ['pipe', 'ignore', 'ignore'] }
+            );
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    return false;
+};
+
+/**
+ * Test-only — clear the in-memory cache so a test that re-stubs the key
+ * store sees a fresh load.
+ */
+export const __resetKeyCacheForTests = (): void => {
+    cachedKey = null;
+};


### PR DESCRIPTION
## Summary
- Replaces \`scryptSync(\`hostname-username\`)\` with a random 32-byte key held in the OS keychain (macOS \`security\`, Linux \`secret-tool\`), falling back to a 0600 keyfile under the app data dir.
- Decryption transparently falls back to the legacy hostname-derived key and re-encrypts under the new key on success — no user action needed for tokens stored before this change.
- When both keys fail, replaces the thrown stack trace with a single actionable \`viwo:\` warning.
- Closes #154.

## Why
The hostname-derived key silently breaks every stored token whenever \`hostname()\` changes (network move, machine rename, sudo, container runs as a different user) and offers little real defense — hostname/username aren't secrets, and the keyspace is brute-forceable in seconds. The original bug surfaced when a GitHub token decrypt failure spammed a stack trace mid-\`viwo start\`.

## Test plan
- [x] \`bun test\` — 134 pass, 0 fail (5 new \`key-store\` tests)
- [x] End-to-end on macOS:
  - \`viwo config github --status\` on the existing (un-decryptable) DB → clean \`viwo:\` warning, no stack
  - \`security find-generic-password -s viwo-encryption-key -w\` → returns the new 32-byte key
  - \`viwo config github --auto\` → stores under new key
  - \`viwo config github --status\` → \`configured\`, no warning
  - \`viwo start ...\` runs cleanly with no decryption errors
- [ ] Reviewer: verify on Linux that \`secret-tool\` works when libsecret is available, and that the keyfile fallback kicks in when it isn't