### PR TITLE
chore: add viwo.Dockerfile for self-hosted agent runs

### DIFF
--- a/viwo.Dockerfile
+++ b/viwo.Dockerfile
@@ -1,0 +1,15 @@
+FROM overseedai/viwo-claude-code:0.10.1
+
+USER root
+
+# Bun's official installer needs `unzip` to extract its archive. Install
+# both unzip and Bun itself at build time so each session starts fast and
+# the preAgent hook just runs `bun install`.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash -s "bun-v1.1.34" \
+    && chmod +x /usr/local/bin/bun
+
+USER claude

--- a/viwo.example.yml
+++ b/viwo.example.yml
@@ -26,6 +26,20 @@ postInstall:
 #   - bun install
 #   - bun run build
 
+# Project Dockerfile that extends the viwo base image. The file's first
+# non-comment line must be `FROM overseedai/viwo-claude-code:<version>`
+# matching the viwo CLI's pinned base. Built once per content hash and
+# tagged `viwo-derived:<hash>`; cached for subsequent sessions.
+#
+# Use this when you need system packages or language runtimes the base
+# image doesn't ship — installing them in `preAgent` is slow and runs as
+# the non-root `claude` user, so it can't `apt-get install`.
+#
+# A working `viwo.Dockerfile` for this repo is checked in alongside this
+# example — copy this file to `viwo.yml` to opt in.
+#
+# dockerfile: ./viwo.Dockerfile
+
 # Custom bind mounts exposed inside the agent container.
 # Host paths may be absolute, use `~` for your home directory, or be
 # relative to the repository root. Container paths must be absolute.


### PR DESCRIPTION
## Summary
- Adds \`viwo.Dockerfile\` extending the pinned base image with \`unzip\` + Bun, so contributors running viwo against this repo get a working \`bun install\` in the container.
- Updates \`viwo.example.yml\` to document the new \`dockerfile:\` field landed in #153/#55.

## Why
The repo's \`preAgent\` previously tried to install Bun at session start via \`curl | BUN_INSTALL=/usr/local bash\`, which fails because the container runs as the non-root \`claude\` user and can't write to \`/usr/local\`. Baking Bun into a derived image fixes this once instead of every session, and demonstrates the new extension feature on the project that ships it.

\`viwo.yml\` is gitignored (per-developer config), so opting in is \`cp viwo.example.yml viwo.yml\` and uncommenting the \`dockerfile:\` line.

## Test plan
- [x] \`viwo start --repo viwo --branch test --prompt ...\` succeeds with \`viwo.yml: dockerfile: ./viwo.Dockerfile\` set
- [x] Container runs on \`viwo-derived:<hash>\`, not the base tag
- [x] \`bun install\` in preAgent completes inside the container (92 packages, 2.69s)
- [x] Second run reuses cached derived image (no rebuild)