### PR TITLE
security: drop Linux capabilities and add no-new-privileges to containers

### DIFF
--- a/packages/core/src/managers/__tests__/docker-manager-security.test.ts
+++ b/packages/core/src/managers/__tests__/docker-manager-security.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect } from 'bun:test';
+import { buildContainerCreateOptions } from '../docker-manager';
+
+describe('docker-manager security', () => {
+    test('drops all Linux capabilities', () => {
+        const config = buildContainerCreateOptions({
+            name: 'test-container',
+            image: 'test-image',
+            worktreePath: '/tmp/test-worktree',
+        });
+
+        expect(config.HostConfig.CapDrop).toEqual(['ALL']);
+    });
+
+    test('sets no-new-privileges security option', () => {
+        const config = buildContainerCreateOptions({
+            name: 'test-container',
+            image: 'test-image',
+            worktreePath: '/tmp/test-worktree',
+        });
+
+        expect(config.HostConfig.SecurityOpt).toEqual(['no-new-privileges:true']);
+    });
+
+    test('security options are present alongside other HostConfig settings', () => {
+        const config = buildContainerCreateOptions({
+            name: 'test-container',
+            image: 'test-image',
+            worktreePath: '/tmp/test-worktree',
+            ports: [{ host: 3000, container: 3000, protocol: 'tcp' as const }],
+            additionalBinds: ['/host/path:/container/path'],
+        });
+
+        expect(config.HostConfig.CapDrop).toEqual(['ALL']);
+        expect(config.HostConfig.SecurityOpt).toEqual(['no-new-privileges:true']);
+        expect(config.HostConfig.AutoRemove).toBe(false);
+        expect(config.HostConfig.Binds).toEqual([
+            '/tmp/test-worktree:/workspace',
+            '/host/path:/container/path',
+        ]);
+        expect(config.HostConfig.PortBindings).toEqual({
+            '3000/tcp': [{ HostPort: '3000' }],
+        });
+    });
+});

--- a/packages/core/src/managers/docker-manager.ts
+++ b/packages/core/src/managers/docker-manager.ts
@@ -158,14 +158,7 @@ export interface CreateContainerOptions {
     additionalBinds?: string[];
 }
 
-export const createContainer = async (options: CreateContainerOptions): Promise<ContainerInfo> => {
-    // Check if image exists locally, if not pull it
-    const imageExists = await checkImageExists({ image: options.image });
-    if (!imageExists) {
-        await pullImage({ image: options.image });
-    }
-
-    // Create port bindings
+export const buildContainerCreateOptions = (options: CreateContainerOptions) => {
     const portBindings: Record<string, { HostPort: string }[]> = {};
     const exposedPorts: Record<string, object> = {};
 
@@ -176,8 +169,7 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
         portBindings[containerPort] = [{ HostPort: port.host.toString() }];
     }
 
-    // Create container
-    const container = await dockerSdk.createContainer({
+    return {
         name: options.name,
         Image: options.image,
         Cmd: options.command,
@@ -186,12 +178,23 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
             PortBindings: Object.keys(portBindings).length > 0 ? portBindings : undefined,
             Binds: [`${options.worktreePath}:/workspace`, ...(options.additionalBinds || [])],
             AutoRemove: false,
+            CapDrop: ['ALL'],
+            SecurityOpt: ['no-new-privileges:true'],
         },
         Env: options.env ? Object.entries(options.env).map(([k, v]) => `${k}=${v}`) : undefined,
         WorkingDir: '/workspace',
         Tty: options.tty ?? false,
         OpenStdin: options.openStdin ?? false,
-    });
+    };
+};
+
+export const createContainer = async (options: CreateContainerOptions): Promise<ContainerInfo> => {
+    const imageExists = await checkImageExists({ image: options.image });
+    if (!imageExists) {
+        await pullImage({ image: options.image });
+    }
+
+    const container = await dockerSdk.createContainer(buildContainerCreateOptions(options));
 
     const info = await container.inspect();
 
@@ -200,7 +203,7 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
         name: info.Name.replace(/^\//, ''),
         image: options.image,
         status: mapContainerStatus(info.State.Status),
-        ports,
+        ports: options.ports || [],
         createdAt: new Date(info.Created),
     };
 };
@@ -667,6 +670,7 @@ export const docker = {
     checkDockerRunningOrThrow,
     checkImageExists,
     buildImage,
+    buildContainerCreateOptions,
     createContainersFromCompose,
     createContainer,
     startContainer,


### PR DESCRIPTION
## Summary
- Adds `CapDrop: ['ALL']` and `SecurityOpt: ['no-new-privileges:true']` to the Docker `HostConfig` in `createContainer()`, dropping all Linux capabilities and preventing privilege escalation via setuid binaries inside agent containers
- Extracts `buildContainerCreateOptions()` as a pure function for testability
- Adds 3 tests verifying the security options are correctly applied

Closes #150

## Test plan
- [x] New tests in `docker-manager-security.test.ts` verify `CapDrop` and `SecurityOpt` are set
- [x] Full test suite passes (113 tests, 0 failures)
- [x] Typecheck passes
- [ ] Verify with a live session that containers start correctly with dropped capabilities

https://claude.ai/code/session_01SV6e1racwY9YtweHokQK11