### PR TITLE
security: drop Linux capabilities and add no-new-privileges to containers

### DIFF
--- a/packages/core/src/managers/__tests__/docker-security.test.ts
+++ b/packages/core/src/managers/__tests__/docker-security.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from 'bun:test';
+import { buildContainerHostConfig } from '../docker-manager';
+
+describe('container security hardening', () => {
+    test('drops all Linux capabilities', () => {
+        const hostConfig = buildContainerHostConfig({
+            worktreePath: '/tmp/test-workspace',
+        });
+
+        expect(hostConfig.CapDrop).toEqual(['ALL']);
+    });
+
+    test('sets no-new-privileges security option', () => {
+        const hostConfig = buildContainerHostConfig({
+            worktreePath: '/tmp/test-workspace',
+        });
+
+        expect(hostConfig.SecurityOpt).toEqual(['no-new-privileges:true']);
+    });
+
+    test('preserves binds and port mappings alongside security options', () => {
+        const hostConfig = buildContainerHostConfig({
+            worktreePath: '/tmp/test-workspace',
+            additionalBinds: ['/host/path:/container/path'],
+            ports: [{ host: 8080, container: 80, protocol: 'tcp' as const }],
+        });
+
+        expect(hostConfig.Binds).toEqual([
+            '/tmp/test-workspace:/workspace',
+            '/host/path:/container/path',
+        ]);
+        expect(hostConfig.PortBindings).toEqual({
+            '80/tcp': [{ HostPort: '8080' }],
+        });
+        expect(hostConfig.AutoRemove).toBe(false);
+        expect(hostConfig.CapDrop).toEqual(['ALL']);
+        expect(hostConfig.SecurityOpt).toEqual(['no-new-privileges:true']);
+    });
+
+    test('omits PortBindings when no ports provided', () => {
+        const hostConfig = buildContainerHostConfig({
+            worktreePath: '/workspace',
+        });
+
+        expect(hostConfig.PortBindings).toBeUndefined();
+    });
+});

--- a/packages/core/src/managers/docker-manager.ts
+++ b/packages/core/src/managers/docker-manager.ts
@@ -158,35 +158,44 @@ export interface CreateContainerOptions {
     additionalBinds?: string[];
 }
 
+export const buildContainerHostConfig = (options: {
+    worktreePath: string;
+    ports?: PortMapping[];
+    additionalBinds?: string[];
+}) => {
+    const portBindings: Record<string, { HostPort: string }[]> = {};
+
+    for (const port of options.ports || []) {
+        portBindings[`${port.container}/${port.protocol}`] = [{ HostPort: port.host.toString() }];
+    }
+
+    return {
+        PortBindings: Object.keys(portBindings).length > 0 ? portBindings : undefined,
+        Binds: [`${options.worktreePath}:/workspace`, ...(options.additionalBinds || [])],
+        AutoRemove: false,
+        CapDrop: ['ALL'],
+        SecurityOpt: ['no-new-privileges:true'],
+    };
+};
+
 export const createContainer = async (options: CreateContainerOptions): Promise<ContainerInfo> => {
-    // Check if image exists locally, if not pull it
     const imageExists = await checkImageExists({ image: options.image });
     if (!imageExists) {
         await pullImage({ image: options.image });
     }
 
-    // Create port bindings
-    const portBindings: Record<string, { HostPort: string }[]> = {};
     const exposedPorts: Record<string, object> = {};
-
     const ports = options.ports || [];
     for (const port of ports) {
-        const containerPort = `${port.container}/${port.protocol}`;
-        exposedPorts[containerPort] = {};
-        portBindings[containerPort] = [{ HostPort: port.host.toString() }];
+        exposedPorts[`${port.container}/${port.protocol}`] = {};
     }
 
-    // Create container
     const container = await dockerSdk.createContainer({
         name: options.name,
         Image: options.image,
         Cmd: options.command,
         ExposedPorts: Object.keys(exposedPorts).length > 0 ? exposedPorts : undefined,
-        HostConfig: {
-            PortBindings: Object.keys(portBindings).length > 0 ? portBindings : undefined,
-            Binds: [`${options.worktreePath}:/workspace`, ...(options.additionalBinds || [])],
-            AutoRemove: false,
-        },
+        HostConfig: buildContainerHostConfig(options),
         Env: options.env ? Object.entries(options.env).map(([k, v]) => `${k}=${v}`) : undefined,
         WorkingDir: '/workspace',
         Tty: options.tty ?? false,
@@ -667,6 +676,7 @@ export const docker = {
     checkDockerRunningOrThrow,
     checkImageExists,
     buildImage,
+    buildContainerHostConfig,
     createContainersFromCompose,
     createContainer,
     startContainer,


### PR DESCRIPTION
## Summary

- Adds `CapDrop: ['ALL']` and `SecurityOpt: ['no-new-privileges:true']` to Docker `HostConfig` in `createContainer()`, shrinking the kernel attack surface for agent containers
- Extracts `buildContainerHostConfig()` as a pure, testable function for HostConfig construction
- Adds 4 unit tests verifying the security options are always applied and coexist with existing config (binds, ports)

## Context

Agent containers run as non-root user `claude` (UID 10001) and don't need any Linux capabilities. Dropping all caps and preventing privilege escalation via setuid binaries is defense-in-depth that reduces the blast radius of a container compromise.

Closes #150

## Test plan

- [x] All 114 existing tests pass
- [x] 4 new tests in `docker-security.test.ts` verify `CapDrop` and `SecurityOpt` are set
- [x] Type checking passes
- [ ] Manual verification: start a session and inspect the container with `docker inspect` to confirm `CapDrop` and `SecurityOpt` are present

https://claude.ai/code/session_01NLme3xAHXyTj35m7cJvMK8