### PR TITLE
security: drop Linux capabilities and add no-new-privileges

### DIFF
--- a/packages/core/src/managers/__tests__/docker-manager.test.ts
+++ b/packages/core/src/managers/__tests__/docker-manager.test.ts
@@ -1,18 +1,82 @@
 import { describe, test, expect } from 'bun:test';
-import { isDockerRunning } from '../docker-manager';
+import { isDockerRunning, buildContainerConfig } from '../docker-manager';
 
 describe('docker-manager', () => {
     describe('isDockerRunning', () => {
         test('checks if Docker is running', async () => {
-            // This test will pass if Docker is running, fail if not
-            // In a real test suite, you might want to mock the Docker API
             const running = await isDockerRunning();
-
             expect(typeof running).toBe('boolean');
         });
     });
 
-    // Note: Additional tests for createContainer, startContainer, etc.
-    // would require either a running Docker daemon or mocking the Docker API.
-    // For now, we're keeping this test file minimal with just the basic check.
+    describe('buildContainerConfig', () => {
+        test('drops all Linux capabilities', () => {
+            const config = buildContainerConfig({
+                name: 'test',
+                image: 'test-image',
+                worktreePath: '/tmp/test',
+            });
+
+            expect(config.HostConfig.CapDrop).toEqual(['ALL']);
+        });
+
+        test('sets no-new-privileges security option', () => {
+            const config = buildContainerConfig({
+                name: 'test',
+                image: 'test-image',
+                worktreePath: '/tmp/test',
+            });
+
+            expect(config.HostConfig.SecurityOpt).toEqual(['no-new-privileges:true']);
+        });
+
+        test('includes workspace and additional bind mounts', () => {
+            const config = buildContainerConfig({
+                name: 'test',
+                image: 'test-image',
+                worktreePath: '/tmp/test',
+                additionalBinds: ['/host:/container'],
+            });
+
+            expect(config.HostConfig.Binds).toEqual(['/tmp/test:/workspace', '/host:/container']);
+        });
+
+        test('sets port bindings when ports are provided', () => {
+            const config = buildContainerConfig({
+                name: 'test',
+                image: 'test-image',
+                worktreePath: '/tmp/test',
+                ports: [{ host: 8080, container: 80, protocol: 'tcp' }],
+            });
+
+            expect(config.ExposedPorts).toEqual({ '80/tcp': {} });
+            expect(config.HostConfig.PortBindings).toEqual({
+                '80/tcp': [{ HostPort: '8080' }],
+            });
+        });
+
+        test('converts env record to Docker format', () => {
+            const config = buildContainerConfig({
+                name: 'test',
+                image: 'test-image',
+                worktreePath: '/tmp/test',
+                env: { FOO: 'bar', BAZ: 'qux' },
+            });
+
+            expect(config.Env).toEqual(['FOO=bar', 'BAZ=qux']);
+        });
+
+        test('applies tty and openStdin options', () => {
+            const config = buildContainerConfig({
+                name: 'test',
+                image: 'test-image',
+                worktreePath: '/tmp/test',
+                tty: true,
+                openStdin: true,
+            });
+
+            expect(config.Tty).toBe(true);
+            expect(config.OpenStdin).toBe(true);
+        });
+    });
 });

--- a/packages/core/src/managers/docker-manager.ts
+++ b/packages/core/src/managers/docker-manager.ts
@@ -158,14 +158,7 @@ export interface CreateContainerOptions {
     additionalBinds?: string[];
 }
 
-export const createContainer = async (options: CreateContainerOptions): Promise<ContainerInfo> => {
-    // Check if image exists locally, if not pull it
-    const imageExists = await checkImageExists({ image: options.image });
-    if (!imageExists) {
-        await pullImage({ image: options.image });
-    }
-
-    // Create port bindings
+export const buildContainerConfig = (options: CreateContainerOptions) => {
     const portBindings: Record<string, { HostPort: string }[]> = {};
     const exposedPorts: Record<string, object> = {};
 
@@ -176,8 +169,7 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
         portBindings[containerPort] = [{ HostPort: port.host.toString() }];
     }
 
-    // Create container
-    const container = await dockerSdk.createContainer({
+    return {
         name: options.name,
         Image: options.image,
         Cmd: options.command,
@@ -186,12 +178,23 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
             PortBindings: Object.keys(portBindings).length > 0 ? portBindings : undefined,
             Binds: [`${options.worktreePath}:/workspace`, ...(options.additionalBinds || [])],
             AutoRemove: false,
+            CapDrop: ['ALL'],
+            SecurityOpt: ['no-new-privileges:true'],
         },
         Env: options.env ? Object.entries(options.env).map(([k, v]) => `${k}=${v}`) : undefined,
         WorkingDir: '/workspace',
         Tty: options.tty ?? false,
         OpenStdin: options.openStdin ?? false,
-    });
+    };
+};
+
+export const createContainer = async (options: CreateContainerOptions): Promise<ContainerInfo> => {
+    const imageExists = await checkImageExists({ image: options.image });
+    if (!imageExists) {
+        await pullImage({ image: options.image });
+    }
+
+    const container = await dockerSdk.createContainer(buildContainerConfig(options));
 
     const info = await container.inspect();
 
@@ -200,7 +203,7 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
         name: info.Name.replace(/^\//, ''),
         image: options.image,
         status: mapContainerStatus(info.State.Status),
-        ports,
+        ports: options.ports || [],
         createdAt: new Date(info.Created),
     };
 };
@@ -668,6 +671,7 @@ export const docker = {
     checkImageExists,
     buildImage,
     createContainersFromCompose,
+    buildContainerConfig,
     createContainer,
     startContainer,
     stopContainer,


### PR DESCRIPTION
## Summary

- Adds `CapDrop: ['ALL']` and `SecurityOpt: ['no-new-privileges:true']` to the Docker `HostConfig` in `createContainer()`, shrinking the kernel attack surface available to compromised containers
- Extracts `buildContainerConfig()` as a pure function for testability
- Adds 6 new tests covering security settings, bind mounts, port bindings, env vars, and tty options

## Test plan

- [x] All 92 existing tests pass (`bun test`)
- [x] Type checking passes (`bun run typecheck`)
- [x] New `buildContainerConfig` tests verify `CapDrop` and `SecurityOpt` are set
- [ ] Manual verification: start a session and confirm container runs successfully with dropped capabilities (Claude Code doesn't need any Linux capabilities)

Closes #150

https://claude.ai/code/session_01PYkHJ96FF3mU25BQQCdPc3