### PR TITLE
security: drop Linux capabilities and add no-new-privileges to containers

### DIFF
--- a/packages/core/src/managers/__tests__/docker-manager-security.test.ts
+++ b/packages/core/src/managers/__tests__/docker-manager-security.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from 'bun:test';
+import { buildContainerConfig } from '../docker-manager';
+
+describe('docker-manager security hardening', () => {
+    test('drops all Linux capabilities', () => {
+        const config = buildContainerConfig({
+            name: 'test-security',
+            image: 'test-image:latest',
+            worktreePath: '/tmp/test-worktree',
+        });
+
+        expect(config.HostConfig.CapDrop).toEqual(['ALL']);
+    });
+
+    test('sets no-new-privileges security option', () => {
+        const config = buildContainerConfig({
+            name: 'test-security',
+            image: 'test-image:latest',
+            worktreePath: '/tmp/test-worktree',
+        });
+
+        expect(config.HostConfig.SecurityOpt).toEqual(['no-new-privileges:true']);
+    });
+
+    test('preserves existing HostConfig options alongside security settings', () => {
+        const config = buildContainerConfig({
+            name: 'test-security',
+            image: 'test-image:latest',
+            worktreePath: '/tmp/test-worktree',
+            additionalBinds: ['/host/path:/container/path'],
+            ports: [{ container: 3000, host: 3000, protocol: 'tcp' }],
+        });
+
+        expect(config.HostConfig.Binds).toContain('/tmp/test-worktree:/workspace');
+        expect(config.HostConfig.Binds).toContain('/host/path:/container/path');
+        expect(config.HostConfig.AutoRemove).toBe(false);
+        expect(config.HostConfig.CapDrop).toEqual(['ALL']);
+        expect(config.HostConfig.SecurityOpt).toEqual(['no-new-privileges:true']);
+        expect(config.HostConfig.PortBindings).toBeDefined();
+    });
+
+    test('sets correct port bindings', () => {
+        const config = buildContainerConfig({
+            name: 'test',
+            image: 'test:latest',
+            worktreePath: '/tmp/w',
+            ports: [
+                { container: 8080, host: 9090, protocol: 'tcp' },
+                { container: 5432, host: 5432, protocol: 'tcp' },
+            ],
+        });
+
+        expect(config.HostConfig.PortBindings!['8080/tcp']).toEqual([{ HostPort: '9090' }]);
+        expect(config.HostConfig.PortBindings!['5432/tcp']).toEqual([{ HostPort: '5432' }]);
+    });
+
+    test('converts env record to Docker format', () => {
+        const config = buildContainerConfig({
+            name: 'test',
+            image: 'test:latest',
+            worktreePath: '/tmp/w',
+            env: { FOO: 'bar', BAZ: 'qux' },
+        });
+
+        expect(config.Env).toContain('FOO=bar');
+        expect(config.Env).toContain('BAZ=qux');
+    });
+});

--- a/packages/core/src/managers/docker-manager.ts
+++ b/packages/core/src/managers/docker-manager.ts
@@ -158,14 +158,7 @@ export interface CreateContainerOptions {
     additionalBinds?: string[];
 }
 
-export const createContainer = async (options: CreateContainerOptions): Promise<ContainerInfo> => {
-    // Check if image exists locally, if not pull it
-    const imageExists = await checkImageExists({ image: options.image });
-    if (!imageExists) {
-        await pullImage({ image: options.image });
-    }
-
-    // Create port bindings
+export const buildContainerConfig = (options: CreateContainerOptions) => {
     const portBindings: Record<string, { HostPort: string }[]> = {};
     const exposedPorts: Record<string, object> = {};
 
@@ -176,8 +169,7 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
         portBindings[containerPort] = [{ HostPort: port.host.toString() }];
     }
 
-    // Create container
-    const container = await dockerSdk.createContainer({
+    return {
         name: options.name,
         Image: options.image,
         Cmd: options.command,
@@ -186,12 +178,24 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
             PortBindings: Object.keys(portBindings).length > 0 ? portBindings : undefined,
             Binds: [`${options.worktreePath}:/workspace`, ...(options.additionalBinds || [])],
             AutoRemove: false,
+            CapDrop: ['ALL'],
+            SecurityOpt: ['no-new-privileges:true'],
         },
         Env: options.env ? Object.entries(options.env).map(([k, v]) => `${k}=${v}`) : undefined,
         WorkingDir: '/workspace',
         Tty: options.tty ?? false,
         OpenStdin: options.openStdin ?? false,
-    });
+    };
+};
+
+export const createContainer = async (options: CreateContainerOptions): Promise<ContainerInfo> => {
+    // Check if image exists locally, if not pull it
+    const imageExists = await checkImageExists({ image: options.image });
+    if (!imageExists) {
+        await pullImage({ image: options.image });
+    }
+
+    const container = await dockerSdk.createContainer(buildContainerConfig(options));
 
     const info = await container.inspect();
 
@@ -200,7 +204,7 @@ export const createContainer = async (options: CreateContainerOptions): Promise<
         name: info.Name.replace(/^\//, ''),
         image: options.image,
         status: mapContainerStatus(info.State.Status),
-        ports,
+        ports: options.ports || [],
         createdAt: new Date(info.Created),
     };
 };


### PR DESCRIPTION
## Summary

Closes #150.

- Adds `CapDrop: ['ALL']` and `SecurityOpt: ['no-new-privileges:true']` to the Docker `HostConfig` in `createContainer()`, dropping all default Linux capabilities and preventing privilege escalation via setuid binaries inside agent containers.
- Extracts `buildContainerConfig()` as a pure, exported function so the container configuration (including security settings) can be unit-tested without a Docker daemon.
- Adds 5 tests covering capability dropping, no-new-privileges, preservation of existing HostConfig options, port bindings, and env var formatting.

## Test plan

- [x] All 91 tests pass (86 existing + 5 new)
- [x] `@viwo/core` typechecks cleanly
- [x] Lint produces no new warnings/errors
- [ ] Manually verify a started container runs with dropped caps: `docker inspect <container> | jq '.[0].HostConfig.CapDrop'` should show `["ALL"]`
- [ ] Verify Claude Code still functions normally inside the hardened container (no capabilities are actually needed)

https://claude.ai/code/session_01KxrhHLZoKTbstwsY1iDike