### PR TITLE
fix(core): validate auth_method values from config DB

### DIFF
--- a/packages/core/src/managers/__tests__/config-manager.test.ts
+++ b/packages/core/src/managers/__tests__/config-manager.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { db } from '../../db';
+import { configurations } from '../../db-schemas';
+import { getAuthMethod, setAuthMethod } from '../config-manager';
+
+describe('config-manager', () => {
+    beforeEach(() => {
+        db.delete(configurations).run();
+    });
+
+    test('returns api-key when no config row exists', () => {
+        expect(getAuthMethod()).toBe('api-key');
+    });
+
+    test('returns oauth when auth method is oauth', () => {
+        setAuthMethod('oauth');
+
+        expect(getAuthMethod()).toBe('oauth');
+    });
+
+    test('returns api-key when auth method is api-key', () => {
+        setAuthMethod('api-key');
+
+        expect(getAuthMethod()).toBe('api-key');
+    });
+
+    test('returns api-key when auth method is invalid in database', () => {
+        const now = new Date().toISOString();
+
+        db.insert(configurations)
+            .values({
+                authMethod: 'corrupted-value',
+                createdAt: now,
+                updatedAt: now,
+            })
+            .run();
+
+        expect(getAuthMethod()).toBe('api-key');
+    });
+});

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -2,6 +2,7 @@ import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import { db } from '../db';
 import { configurations } from '../db-schemas';
 import { eq } from 'drizzle-orm';
+import { AuthMethodSchema } from '../schemas';
 import type { AuthMethod, IDEType, ModelType } from '../types.js';
 import { expandTilde } from '../utils/paths.js';
 import { getEncryptionKey, getLegacyEncryptionKey } from './key-store';
@@ -508,7 +509,8 @@ export const getAuthMethod = (): AuthMethod => {
         return 'api-key';
     }
 
-    return (config[0]!.authMethod as AuthMethod) || 'api-key';
+    const parsedAuthMethod = AuthMethodSchema.safeParse(config[0]!.authMethod);
+    return parsedAuthMethod.success ? parsedAuthMethod.data : 'api-key';
 };
 
 export const isAuthConfigured = (): boolean => {


### PR DESCRIPTION
## Summary
- validate `configurations.auth_method` with `AuthMethodSchema.safeParse()` in `getAuthMethod()`
- preserve the existing `'api-key'` fallback for missing or invalid values
- add focused tests covering missing, valid, and corrupted DB values

## Why
Issue #71 called out that `getAuthMethod()` was casting the DB value with `as AuthMethod`, which let corrupted values bypass schema validation. This change makes the runtime behavior match the declared enum schema.

## Verification
### Ticket completion proof
Added targeted tests that prove:
- no config row returns `'api-key'`
- `'oauth'` returns `'oauth'`
- `'api-key'` returns `'api-key'`
- a corrupted DB value returns `'api-key'`

### Commands run
- `NODE_ENV=test pnpm dlx bun test packages/core/src/managers/__tests__/config-manager.test.ts` ✅
- `pnpm dlx bun x tsc --noEmit --module ESNext --moduleResolution bundler --target ES2022 --types bun --skipLibCheck packages/core/src/managers/config-manager.ts packages/core/src/managers/__tests__/config-manager.test.ts` ✅
- `pnpm --dir packages/core run typecheck` ⚠️ fails in the current repo state with `TS2688: Cannot find type definition file for 'bun-types'`

## Regression risk
Low. The change is isolated to `getAuthMethod()` and the added tests cover both valid stored values and corrupted data fallback behavior.

Closes #71.
